### PR TITLE
Adding executable python script to deploy AMIs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 boto==2.39.0
+click>=6.0,<7.0
+requests>=2.9.1,<3.0
 # Replace this line with a PyPI line as soon as a new PyGithub release is published
 # containing the commit 5823ed7, which is already merged upstream.
 git+https://github.com/doctoryes/PyGithub.git@v2.0.0-alpha.4-edx1#egg=PyGithub

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,6 +1,5 @@
 ddt==1.0.1
 nose==1.3.7
 moto==0.4.21
-click==6.2
 
 -r ../requirements.txt

--- a/scripts/asgard-deploy.py
+++ b/scripts/asgard-deploy.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import sys
+import logging
+import click
+import tubular.asgard as asgard
+
+logging.basicConfig(stream=sys.stdout, level=logging.ERROR)
+
+@click.command()
+@click.option('--ami_id', help='The ami-id to deploy', required=True)
+def deploy(ami_id):
+    try:
+        asgard.deploy(ami_id)
+    except Exception, e:
+        click.secho("Error Deploying AMI: {0}.\nMessage: {1}".format(ami_id, e.message), fg='red')
+        sys.exit(1)
+
+    sys.exit(0)
+
+if __name__ == "__main__":
+    deploy()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,9 @@ setup(
     description='Continuous Delivery scripts for pipeline evaluation',
     packages=['tubular', 'tubular.gocd', 'tubular.scripts', 'tubular.scripts.github', 'tubular.scripts.hipchat'],
     install_requires=[
+        'boto==2.39.0',
         'click>=6.2',
         'requests>=2.9',
     ],
+    scripts=['scripts/asgard-deploy.py']
 )

--- a/tubular/asgard.py
+++ b/tubular/asgard.py
@@ -226,6 +226,19 @@ def elbs_for_asg(asg):
 
 
 def deploy(ami_id):
+    """
+    Deploys an AMI to AWS EC2
+
+    Arguments:
+        ami_id(str): AWS AMI ID
+
+    Returns:
+        None
+
+    Raises:
+        TimeoutException: When the task to bring up the new instance times out.
+        BackendError: When the task to bring up the new instance fails.
+    """
     LOG.info( "Processing request to deploy {}.".format(ami_id))
 
     # Pull the EDC from the AMI ID


### PR DESCRIPTION
This installs the asgard-deploy.py as an executable script in to the python environment.

@feanil @doctoryes PTAL.
