### PR TITLE
Don't pct encode the token.

### DIFF
--- a/tubular/asgard.py
+++ b/tubular/asgard.py
@@ -11,7 +11,7 @@ import ec2
 
 
 ASGARD_API_ENDPOINT = os.environ.get("ASGARD_API_ENDPOINTS", "http://dummy.url:8091/us-east-1")
-ASGARD_API_TOKEN = {"asgardApiToken": os.environ.get("ASGARD_API_TOKEN", "dummy-token")}
+ASGARD_API_TOKEN = "asgardApiToken={}".format(os.environ.get("ASGARD_API_TOKEN", "dummy-token"))
 ASGARD_WAIT_TIMEOUT = int(os.environ.get("ASGARD_WAIT_TIMEOUT", 300))
 REQUESTS_TIMEOUT = os.environ.get("REQUESTS_TIMEOUT", 10)
 


### PR DESCRIPTION
The tokens can have characters that requests doesn't percent encode correctly(the '%' character)

@edx/pipeline-team 
