### PR TITLE
Bug Fix: Requests Timeout

### DIFF
--- a/tubular/asgard.py
+++ b/tubular/asgard.py
@@ -13,7 +13,7 @@ import ec2
 ASGARD_API_ENDPOINT = os.environ.get("ASGARD_API_ENDPOINTS", "http://dummy.url:8091/us-east-1")
 ASGARD_API_TOKEN = "asgardApiToken={}".format(os.environ.get("ASGARD_API_TOKEN", "dummy-token"))
 ASGARD_WAIT_TIMEOUT = int(os.environ.get("ASGARD_WAIT_TIMEOUT", 300))
-REQUESTS_TIMEOUT = os.environ.get("REQUESTS_TIMEOUT", 10)
+REQUESTS_TIMEOUT = float(os.environ.get("REQUESTS_TIMEOUT", 10))
 
 
 CLUSTER_LIST_URL= "{}/cluster/list.json".format(ASGARD_API_ENDPOINT)


### PR DESCRIPTION
Requests expects a float so a string from the environment doesn't work.
