### PR TITLE
Add top-level module path before tubular import.

### DIFF
--- a/scripts/asgard-deploy.py
+++ b/scripts/asgard-deploy.py
@@ -2,7 +2,13 @@
 import sys
 import logging
 import click
-import tubular.asgard as asgard
+from os import path
+
+# Add top-level module path to sys.path before importing tubular code.
+sys.path.append( path.dirname( path.dirname( path.abspath(__file__) ) ) )
+
+from tubular import asgard
+
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 


### PR DESCRIPTION
@macdiesel OK - this method works with no tubular install. The effects should only last for the life of the script. What do you think?

@feanil FYI.
