### PR TITLE
Added ability to set the sleep time while waiting for tasks to complete.

### DIFF
--- a/tubular/asgard.py
+++ b/tubular/asgard.py
@@ -16,6 +16,7 @@ ASGARD_API_ENDPOINT = os.environ.get("ASGARD_API_ENDPOINTS", "http://dummy.url:8
 ASGARD_API_TOKEN = "asgardApiToken={}".format(os.environ.get("ASGARD_API_TOKEN", "dummy-token"))
 ASGARD_WAIT_TIMEOUT = int(os.environ.get("ASGARD_WAIT_TIMEOUT", 600))
 REQUESTS_TIMEOUT = float(os.environ.get("REQUESTS_TIMEOUT", 10))
+WAIT_SLEEP_TIME = int(os.environ.get("WAIT_SLEEP_TIME", 5))
 
 
 CLUSTER_LIST_URL= "{}/cluster/list.json".format(ASGARD_API_ENDPOINT)
@@ -138,7 +139,7 @@ def wait_for_task_completion(task_url, timeout):
         status = response.json()['status']
         if status == 'completed' or status == 'failed':
             return response.json()
-        time.sleep(1)
+        time.sleep(WAIT_SLEEP_TIME)
 
     raise exception.TimeoutException("Timedout while waiting for task {}".format(task_url))
 

--- a/tubular/tests/test_asgard.py
+++ b/tubular/tests/test_asgard.py
@@ -409,9 +409,10 @@ class TestAsgard(unittest.TestCase):
                 ],
             content_type="application/json")
 
-        actual_output = wait_for_task_completion(task_url, 2)
-        expected_output = json.loads(failed_sample_task)
-        self.assertEqual(expected_output, actual_output)
+        with mock.patch('tubular.asgard.WAIT_SLEEP_TIME', 1):
+            actual_output = wait_for_task_completion(task_url, 2)
+            expected_output = json.loads(failed_sample_task)
+            self.assertEqual(expected_output, actual_output)
 
     @httpretty.activate
     def test_task_timeout(self):


### PR DESCRIPTION
@doctoryes @feanil This doesn't solve the issue error handling when we run into throttling, however it will reduce the number of calls being made against the AWS API. Not the solution but a step towards better AWS usage.

PTAL.
