### PR TITLE
delete_asg expects a string not a boto AutoScale object.

### DIFF
--- a/scripts/cleanup-asgs.py
+++ b/scripts/cleanup-asgs.py
@@ -21,7 +21,7 @@ def delete_asg():
         asgs = get_asgs_pending_delete()
         for asg in asgs:
             try:
-                asgard.delete_asg(asg)
+                asgard.delete_asg(asg.name)
             except Exception as e:
                 click.secho("Unable to delete ASG: {0} - {1}".format(asg, e.message), fg='red')
                 error = True


### PR DESCRIPTION
@edx/pipeline-team 

There a mismatch between the return type of the `get_asgs_pending_delete` and the input type of `asgard.delete_asg`.  The output is a list of `boto` objects but the input of the delete command is the string name of the ASG.
