### PR TITLE
Handle the case where too many ASGs already exist for a culster.

### DIFF
--- a/tubular/asgard.py
+++ b/tubular/asgard.py
@@ -181,9 +181,9 @@ def new_asg(cluster, ami_id):
     LOG.debug("Sent request to create new ASG in Cluster({}).".format(cluster))
 
     if response.status_code == 404:
-        msg = "Can't create more ASGs for cluster {}, please wait " \
-              "till older ASGs have been cleaned up or manually clean " \
-              "up old ASGs."
+        msg = "Can't create more ASGs for cluster {}. Please either wait " \
+              "until older ASGs have been removed automatically or remove " \
+              "old ASGs manually via Asgard."
         raise exception.BackendError(msg.format(cluster))
 
     response = wait_for_task_completion(response.url, ASGARD_WAIT_TIMEOUT)

--- a/tubular/asgard.py
+++ b/tubular/asgard.py
@@ -180,7 +180,12 @@ def new_asg(cluster, ami_id):
             data=payload, params=ASGARD_API_TOKEN, timeout=REQUESTS_TIMEOUT)
     LOG.debug("Sent request to create new ASG in Cluster({}).".format(cluster))
 
-    #TODO: Make sure response is not an error.
+    if response.status_code == 404:
+        msg = "Can't create more ASGs for cluster {}, please wait " \
+              "till older ASGs have been cleaned up or manually clean " \
+              "up old ASGs."
+        raise exception.BackendError(msg.format(cluster))
+
     response = wait_for_task_completion(response.url, ASGARD_WAIT_TIMEOUT)
     if response['status'] == 'failed':
         msg = "Failure during new ASG creation. Task Log: \n{}".format(response['log'])

--- a/tubular/tests/test_asgard.py
+++ b/tubular/tests/test_asgard.py
@@ -529,7 +529,7 @@ class TestAsgard(unittest.TestCase):
             httpretty.POST,
             asgard.NEW_ASG_URL,
             body=post_callback,
-            )
+        )
 
         self.assertRaises(BackendError, asgard.new_asg, cluster, ami_id)
 

--- a/tubular/tests/test_asgard.py
+++ b/tubular/tests/test_asgard.py
@@ -496,10 +496,10 @@ class TestAsgard(unittest.TestCase):
             return (302, response_headers, response_body)
 
         httpretty.register_uri(
-                httpretty.POST,
+            httpretty.POST,
             asgard.NEW_ASG_URL,
-                body=post_callback,
-                Location=task_url)
+            body=post_callback,
+            Location=task_url)
 
         httpretty.register_uri(
             httpretty.GET,
@@ -515,6 +515,23 @@ class TestAsgard(unittest.TestCase):
             content_type="application/json")
 
         self.assertRaises(BackendError, asgard.new_asg,cluster,ami_id)
+
+    @httpretty.activate
+    def test_new_asg_404(self):
+        cluster = "loadtest-edx-edxapp"
+        ami_id = "ami-abc1234"
+
+        def post_callback(request, uri, headers):
+            response_headers = { "server": asgard.ASGARD_API_ENDPOINT }
+            return (404, response_headers, "")
+
+        httpretty.register_uri(
+            httpretty.POST,
+            asgard.NEW_ASG_URL,
+            body=post_callback,
+            )
+
+        self.assertRaises(BackendError, asgard.new_asg, cluster, ami_id)
 
     @httpretty.activate
     @mock.patch('boto.connect_autoscale')


### PR DESCRIPTION
When you try to create a new ASG for a cluster that already has too many
ASGs in it, Asgard responds with a 404 for the endpoint to make more ASGs.

@doctoryes 
