### PR TITLE
We don't care about deletion when trying to determine clusters.

### DIFF
--- a/tubular/asgard.py
+++ b/tubular/asgard.py
@@ -389,7 +389,7 @@ def deploy(ami_id):
     edp = ec2.edp_for_ami(ami_id)
 
     # These are all autoscaling groups that match the tags we care about.
-    asgs = ec2.asgs_for_edp(edp)
+    asgs = ec2.asgs_for_edp(edp, filter_asgs_pending_delete=False)
 
     # All the ASGs except for the new one
     # we are about to make.


### PR DESCRIPTION
In the deploy function we get the list of ASGs so that we can deterimen
relevant clusters to deploy to.  We don't care if some of the existing
ASGs in that cluster are pending deletes.

https://openedx.atlassian.net/browse/TE-1466
