### PR TITLE
no longer raise exception when trying to tag an ASG that does not exist

### DIFF
--- a/tubular/asgard.py
+++ b/tubular/asgard.py
@@ -542,6 +542,9 @@ def deploy(ami_id):
     for cluster,asgs in existing_clusters.iteritems():
         for asg in asgs:
             disable_asg(asg)
-            ec2.tag_asg_for_deletion(asg)
+            try:
+                ec2.tag_asg_for_deletion(asg)
+            except ASGDoesNotExistException as e:
+                LOG.info("Unable to tag ASG {} as it no longer exists, skipping".format(asg))
 
     LOG.info("Woot! Deploy Done!")


### PR DESCRIPTION
@edx/pipeline-team PTAL
