### PR TITLE
Don't add newest ASG to dict until new_asg() completes without failure.

### DIFF
--- a/tubular/asgard.py
+++ b/tubular/asgard.py
@@ -555,9 +555,10 @@ def deploy(ami_id):
     new_clustered_asgs = defaultdict(list)
     for cluster in existing_clustered_asgs.keys():
         try:
-            new_clustered_asgs[cluster].append(new_asg(cluster, ami_id))
+            newest_asg = new_asg(cluster, ami_id)
+            new_clustered_asgs[cluster].append(newest_asg)
         except:
-            msg = "ASG creation failed for cluster {} but succeeded for cluster(s) {}."
+            msg = "ASG creation failed for cluster '{}' but succeeded for cluster(s) {}."
             msg = msg.format(cluster, new_clustered_asgs.keys())
             LOG.error(msg)
             raise


### PR DESCRIPTION
The current code is causing confusing messages such as this one:

```
18:20:00.716 ERROR:tubular.asgard:ASG creation failed for cluster loadtest-edx-discovery but succeeded for cluster(s) [u'loadtest-edx-discovery'].
```

@edx/pipeline-team Please review.
