### PR TITLE
Change default timeout for ASG creation.

### DIFF
--- a/tubular/asgard.py
+++ b/tubular/asgard.py
@@ -30,7 +30,8 @@ from tubular.utils import WAIT_SLEEP_TIME, DISABLE_OLD_ASG_WAIT_TIME
 
 ASGARD_API_ENDPOINT = os.environ.get("ASGARD_API_ENDPOINTS", "http://dummy.url:8091/us-east-1")
 ASGARD_API_TOKEN = "asgardApiToken={}".format(os.environ.get("ASGARD_API_TOKEN", "dummy-token"))
-ASGARD_NEW_ASG_CREATION_TIMEOUT = int(os.environ.get("ASGARD_NEW_ASG_CREATION_TIMEOUT", 1200))
+# Asgard's ASG creation times out at 25 minutes - set tubular's timeout to 26 minutes (1560 seconds).
+ASGARD_NEW_ASG_CREATION_TIMEOUT = int(os.environ.get("ASGARD_NEW_ASG_CREATION_TIMEOUT", 1560))
 ASGARD_ELB_HEALTH_TIMEOUT = int(os.environ.get("ASGARD_ELB_HEALTH_TIMEOUT", 600))
 REQUESTS_TIMEOUT = float(os.environ.get("REQUESTS_TIMEOUT", 10))
 

--- a/tubular/asgard.py
+++ b/tubular/asgard.py
@@ -30,7 +30,7 @@ from tubular.utils import WAIT_SLEEP_TIME, DISABLE_OLD_ASG_WAIT_TIME
 
 ASGARD_API_ENDPOINT = os.environ.get("ASGARD_API_ENDPOINTS", "http://dummy.url:8091/us-east-1")
 ASGARD_API_TOKEN = "asgardApiToken={}".format(os.environ.get("ASGARD_API_TOKEN", "dummy-token"))
-ASGARD_WAIT_TIMEOUT = int(os.environ.get("ASGARD_WAIT_TIMEOUT", 600))
+ASGARD_NEW_ASG_CREATION_TIMEOUT = int(os.environ.get("ASGARD_NEW_ASG_CREATION_TIMEOUT", 1200))
 ASGARD_ELB_HEALTH_TIMEOUT = int(os.environ.get("ASGARD_ELB_HEALTH_TIMEOUT", 600))
 REQUESTS_TIMEOUT = float(os.environ.get("REQUESTS_TIMEOUT", 10))
 
@@ -211,7 +211,7 @@ def new_asg(cluster, ami_id):
         msg = "Error occured attempting to create new ASG for cluster {}.\nResponse: {}"
         raise BackendError(msg.format(cluster, response.text))
 
-    response = wait_for_task_completion(response.url, ASGARD_WAIT_TIMEOUT)
+    response = wait_for_task_completion(response.url, ASGARD_NEW_ASG_CREATION_TIMEOUT)
     if response['status'] == 'failed':
         msg = "Failure during new ASG creation. Task Log: \n{}".format(response['log'])
         raise BackendError(msg)


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TE-1805

This PR changes the name of ASG creation timeout var from `ASGARD_WAIT_TIMEOUT` to `ASGARD_NEW_ASG_CREATION_TIMEOUT`, which is more specific. I checked the edx-gomatic repo and no pipelines currently specify this environment variable - they all use the default timeout.

It appears that Asgard itself times out at 25 minutes. This PR changes the tubular timeout default to 20 minutes.

@edx/pipeline-team Please review.