### PR TITLE
create branch now returns github.GitRef.GitRef

### DIFF
--- a/tubular/release.py
+++ b/tubular/release.py
@@ -120,17 +120,16 @@ class GitRelease(object):
             sha (str): The commit to base the branch off of
 
         Returns:
-            github.Branch.Branch
+            github.GitRef.GitRef
 
         Raises:
             github.GithubException.GithubException: If the branch isn't created/already exists.
             github.GithubException.UnknownObjectException: if the branch can not be fetched after creation
         """
-        self.github_repo.create_git_ref(
+        return self.github_repo.create_git_ref(
             ref='refs/heads/{}'.format(branch_name),
             sha=sha
         )
-        return self.github_repo.get_branch(branch_name)
 
     def create_pull_request(
             self,

--- a/tubular/tests/test_release.py
+++ b/tubular/tests/test_release.py
@@ -114,7 +114,6 @@ class GitHubApiTestCase(TestCase):
         self.api.create_branch(branch_name, sha)
 
         create_git_ref_mock.assert_called_with(ref='refs/heads/{}'.format(branch_name), sha=sha)
-        self.repo_mock.get_branch.assert_called_with(branch_name)
 
     @ddt.data(
         ('blah-candidate', 'release', 'test', 'test_pr'),


### PR DESCRIPTION
Prevents sync errors with github when a new branch may not be available for a few seconds after creation.

@edx/pipeline-team PTAL.

CC: @cpennington 