### PR TITLE
Configure logging for jenkins jobs

### DIFF
--- a/scripts/jenkins_trigger_build.py
+++ b/scripts/jenkins_trigger_build.py
@@ -3,8 +3,10 @@ Command-line script to trigger a jenkins job
 """
 from __future__ import unicode_literals
 
-import sys
+import logging
 from os import path
+import sys
+
 import click
 
 # Add top-level module path to sys.path before importing tubular code.
@@ -67,4 +69,7 @@ def trigger(url, user_name, user_token, job, token, cause, param):
     jenkins.trigger_build(url, user_name, user_token, job, token, cause, param)
 
 if __name__ == "__main__":
+    # Configure logging so that the tubular module methods will
+    # output to stdout of the console that called this script.
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
     trigger()  # pylint: disable=no-value-for-parameter

--- a/scripts/jenkins_trigger_build.py
+++ b/scripts/jenkins_trigger_build.py
@@ -1,8 +1,6 @@
 """
 Command-line script to trigger a jenkins job
 """
-from __future__ import unicode_literals
-
 import logging
 from os import path
 import sys
@@ -17,59 +15,57 @@ from tubular import jenkins  # pylint: disable=wrong-import-position
 
 @click.command()
 @click.option(
-    "--url",
-    help="The base jenkins URL. E.g. https://test-jenkins.testeng.edx.org",
+    u"--url",
+    help=u"The base jenkins URL. E.g. https://test-jenkins.testeng.edx.org",
     type=str,
     required=True,
-    default="https://test-jenkins.testeng.edx.org"
+    default=u"https://test-jenkins.testeng.edx.org"
 )
 @click.option(
-    "--user_name",
-    help="The Jenkins username for triggering the job.",
-    type=str,
-    required=True,
-)
-@click.option(
-    "--user_token",
-    help="API token for the user. Available at {url}/user/{user_name)/configure",
-    type=str,
-    required=True,
-    envvar='JENKINS_USER_TOKEN'
-)
-@click.option(
-    "--job",
-    help="The name of the jenkins job. E.g. test-project",
+    u"--user_name",
+    help=u"The Jenkins username for triggering the job.",
     type=str,
     required=True,
 )
 @click.option(
-    "--token",
-    help="The authorization token for the job. Must match that configured in the job definition.",
+    u"--user_token",
+    help=u"API token for the user. Available at {url}/user/{user_name)/configure",
     type=str,
     required=True,
-    envvar='JENKINS_JOB_TOKEN'
+    envvar=u'JENKINS_USER_TOKEN'
 )
 @click.option(
-    "--cause",
-    help="Text that will be included in the recorded build cause.",
+    u"--job",
+    help=u"The name of the jenkins job. E.g. test-project",
+    type=str,
+    required=True,
+)
+@click.option(
+    u"--token",
+    help=u"The authorization token for the job. Must match that configured in the job definition.",
+    type=str,
+    required=True,
+    envvar=u'JENKINS_JOB_TOKEN'
+)
+@click.option(
+    u"--cause",
+    help=u"Text that will be included in the recorded build cause.",
     type=str,
     required=False,
 )
 @click.option(
-    '--param',
-    help=u'Key/value pairs to pass to the job as parameters. E.g. --param FOO bar --param BAZ biz',
+    u"--param",
+    help=u"Key/value pairs to pass to the job as parameters. E.g. --param FOO bar --param BAZ biz",
     multiple=True,
     required=False,
     type=(str, str)
 )
 def trigger(url, user_name, user_token, job, token, cause, param):
-    """
-    Trigger a jenkins job.
-    """
+    u"""Trigger a jenkins job. """
     jenkins.trigger_build(url, user_name, user_token, job, token, cause, param)
 
-if __name__ == "__main__":
-    # Configure logging so that the tubular module methods will
-    # output to stdout of the console that called this script.
+if __name__ == u"__main__":
+    # Configure logging for the tubular module methods to
+    # print to stdout of the console that called this script.
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
     trigger()  # pylint: disable=no-value-for-parameter

--- a/tubular/jenkins.py
+++ b/tubular/jenkins.py
@@ -101,12 +101,15 @@ def trigger_build(base_url, user_name, user_token, job_name, job_token, job_caus
     # This will start the job and will return a QueueItem object which can be used to get build results
     job = jenkins[job_name]
     queue_item = job.invoke(securitytoken=job_token, build_params=request_params, cause=job_cause)
-    LOG.info(queue_item)
+    LOG.info(u'Added item to jenkins. Server: {} Job: {} '.format(
+        jenkins.base_server_url(), queue_item
+    ))
 
     # Block this script until we are through the queue and the job has begun to build.
     queue_item.block_until_building()
     build = queue_item.get_build()
-    LOG.info(build)
+    LOG.info(u'Created build {}'.format(build))
+    LOG.info(u'See {}'.format(build.baseurl))
 
     # Now block until you get a result back from the build.
     poll_build_for_result(build)


### PR DESCRIPTION
@edx/pipeline-team PTAL

The output on the gocd console wasn't particularly helpful. 

BEFORE:
```
19:16:00.078 scripts/jenkins_trigger_build.py:61: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
19:16:00.078   type=(str, str)
19:16:00.078 scripts/jenkins_trigger_build.py:70: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
19:16:00.078   trigger()  # pylint: disable=no-value-for-parameter
19:16:35.800 [go] Current job status: passed.
```

AFTER should be something like this:
```
INFO:tubular.jenkins:Added item to jenkins. Server: https://test-jenkins.testeng.edx.org Job: jz-test-project Queue #1054 
INFO:tubular.jenkins:Created build jz-test-project #127
INFO:tubular.jenkins:See https://test-jenkins.testeng.edx.org/job/jz-test-project/127
INFO:tubular.jenkins:Build status: SUCCESS
```