### PR TITLE
TE-1936 - Add method to generate a diff between two commits

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pycrypto
 pyyaml==3.12
 PyGithub==1.29
 requests>=2.9.1,<3.0
+validators

--- a/tubular/exception.py
+++ b/tubular/exception.py
@@ -54,3 +54,7 @@ class CannotDeleteLastASG(Exception):
 
 class ASGCountZeroException(Exception):
     pass
+
+
+class InvalidUrlException(Exception):
+    pass

--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -6,11 +6,13 @@ import logging
 import os
 import string
 
+from tubular.exception import InvalidUrlException
 from github import Github
 from github.Commit import Commit
 from github.GitCommit import GitCommit
 from github.GithubException import UnknownObjectException
 from github.InputGitAuthor import InputGitAuthor
+from validators import url as url_validator
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
@@ -120,6 +122,31 @@ class GitHubAPI(object):
             github.GithubException.UnknownObjectException: If the branch does not exist
         """
         return self.get_pull_request(pr_number).head.sha
+
+    def get_diff_url(self, organization, repository, base_sha, head_sha):
+        """
+        Given the organization and repository, generate a github URL that will compare the provided SHAs.
+
+        Arguments:
+            organization (str): An organization name as it will appear in github
+            repository (str): The organization's repository name
+            base_sha (str): The base commit's SHA
+            head_sha (str): Compare the base SHA with this commit
+
+        Returns:
+            A string constaining the URL
+
+        Raises:
+            InvalidUrlException: If the basic validator does not believe this to be a valid URL
+        """
+        calculated_url = 'https://github.com/{}/{}/compare/{}...{}'.format(
+            organization, repository, base_sha, head_sha
+        )
+
+        if not url_validator(calculated_url):
+            raise InvalidUrlException(calculated_url)
+
+        return calculated_url
 
     def check_pull_request_test_status(self, pr_number):
         """

--- a/tubular/tests/test_github.py
+++ b/tubular/tests/test_github.py
@@ -26,6 +26,7 @@ from github.PullRequest import PullRequest
 from github.Repository import Repository
 
 from tubular import github_api
+from tubular.exception import InvalidUrlException
 from tubular.github_api import (
     GitHubAPI,
     NoValidCommitsError,
@@ -105,6 +106,17 @@ class GitHubApiTestCase(TestCase):
         self.repo_mock.get_branch.assert_called_with('test')
         self.repo_mock.get_commits.assert_called_with('123')
         self.assertEqual(len(commits), 10)
+
+    def test_get_diff_url(self):
+        def _check_url(org, repo, base_sha, head_sha):
+            """ private method to do the comparison of the expected URL and the one we get back """
+            url = self.api.get_diff_url(org, repo, base_sha, head_sha)
+            expected = 'https://github.com/{}/{}/compare/{}...{}'.format(org, repo, base_sha, head_sha)
+            self.assertEqual(url, expected)
+
+        _check_url('org', 'repo', 'base-sha', 'head-sha')
+        with self.assertRaises(InvalidUrlException):
+            _check_url('org', 'repo', 'abc def', 'head-sha')
 
     def test_get_commits_by_branch_branch_not_found(self):
         self.repo_mock.get_branch.side_effect = GithubException(


### PR DESCRIPTION
Added a method to generate a simple URL to do a diff (in github) against two commit SHAs.  If the
URL is not valid (invalid domain, space in one of the slugs, etc., the method will throw an InvalidUrlException.