### PR TITLE
Handle possibility of not creating merge PR.

### DIFF
--- a/scripts/create_tag.py
+++ b/scripts/create_tag.py
@@ -16,6 +16,7 @@ import click
 sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular.github_api import GitHubAPI  # pylint: disable=wrong-import-position
+from tubular.utils import exactly_one_set  # pylint: disable=wrong-import-position
 from github.GithubException import GithubException  # pylint: disable=wrong-import-position
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
@@ -81,14 +82,8 @@ def create_tag(org,
     """
     github_api = GitHubAPI(org, repo, token)
 
-    def _exactly_one_set(param_list):
-        """
-        Guarantees that only one of the cmd-line params list have a value set.
-        """
-        return sum(int(bool(param)) for param in param_list) == 1
-
     # Check for one and only one of the mutually-exclusive params.
-    if not _exactly_one_set((commit_sha, input_file, branch_name)):
+    if not exactly_one_set((commit_sha, input_file, branch_name)):
         err_msg = \
             "Exactly one of commit_sha ({!r}), input_file ({!r})," \
             " and branch_name ({!r}) should be specified.".format(
@@ -96,7 +91,8 @@ def create_tag(org,
                 input_file,
                 branch_name
             )
-        raise Exception(err_msg)
+        LOG.error(err_msg)
+        sys.exit(1)
 
     if input_file:
         input_vars = yaml.safe_load(open(input_file, 'r'))  # pylint: disable=open-builtin

--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -287,7 +287,7 @@ class GitHubAPI(object):
             github.GithubException.UnknownObjectException: If the branch does not exist
         """
         commit_sha = self.get_head_commit_from_pull_request(pr_number)
-        return self._poll_commit(commit_sha) == 'success'
+        return self.poll_for_commit_successful(commit_sha)
 
     def poll_for_commit_successful(self, sha):
         """
@@ -475,6 +475,27 @@ class GitHubAPI(object):
         self.github_repo.create_git_ref(ref='refs/tags/{}'.format(tag_name), sha=sha)
 
         return created_tag
+
+    def have_branches_diverged(self, base_branch, compare_branch):
+        """
+        Checks to see if all the commits that are in the compare_branch are already in the base_branch.
+
+        Arguments:
+            base_branch (str): Branch to use as a base when comparing.
+            compare_branch (str): Branch to compare against base to see if it contains commits the base does not.
+
+        Returns:
+            bool: False if all commits in the compare_branch are already in the base_branch.
+                  True if the compare_branch contains commits which the base_branch does not.
+
+        Raises:
+            github.GithubException.GithubException: If the call fails.
+            github.GithubException.UnknownObjectException: If either branch does not exist.
+        """
+        return self.github_repo.compare(
+            base='refs/heads/{}'.format(base_branch),
+            head='refs/heads/{}'.format(compare_branch)
+        ).status == 'diverged'
 
     def is_commit_successful(self, sha):
         """

--- a/tubular/tests/test_github.py
+++ b/tubular/tests/test_github.py
@@ -194,6 +194,16 @@ class GitHubApiTestCase(TestCase):
             )
 
     @ddt.data(
+        ('diverged', True),
+        ('divergent', False),
+        ('ahead', False)
+    )
+    @ddt.unpack
+    def test_have_branches_diverged(self, status, expected):
+        self.repo_mock.compare.return_value = Mock(spec=Comparison, status=status)
+        self.assertEqual(self.api.have_branches_diverged('base', 'head'), expected)
+
+    @ddt.data(
         ('123', range(10), 'SuCcEsS', True),
         ('123', range(10), 'success', True),
         ('123', range(10), 'SUCCESS', True),

--- a/tubular/utils/__init__.py
+++ b/tubular/utils/__init__.py
@@ -13,3 +13,10 @@ WAIT_SLEEP_TIME = int(os.environ.get("WAIT_SLEEP_TIME", 5))
 DISABLE_OLD_ASG_WAIT_TIME = int(os.environ.get("DISABLE_OLD_ASG_WAIT_TIME", 0))
 
 EDP = namedtuple('EDP', ['environment', 'deployment', 'play'])
+
+
+def exactly_one_set(param_list):
+    """
+    Guarantees that only one of the cmd-line params list have a value set.
+    """
+    return sum(int(bool(param)) for param in param_list) == 1


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TE-1954

In the case where a successful fast-forward merge occurs in merging the release candidate, no commits need to be merged to master. Handle this possibility by passing around whether or not a PR was created via the artifact.

@edx/pipeline-team @cpennington Please review.