### PR TITLE
Add a script to publish a release page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 atlassian-python-api==0.13.2; python_version >= '3.2'
 enum34 >=1.1.6, <2.0; python_version < '3.4'
-backoff>=1.3.2,<2.0
+backoff>=1.3.2,<1.4.0
 boto==2.43.0
 click>=6.0,<7.0
 jenkinsapi==0.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,13 @@
+atlassian-python-api==0.13.2; python_version >= '3.2'
+enum34 >=1.1.6, <2.0; python_version < '3.4'
 backoff>=1.3.2,<2.0
 boto==2.43.0
 click>=6.0,<7.0
 jenkinsapi==0.3.3
+lxml >= 3.7, <3.8
 pycrypto
-pyyaml==3.12
 PyGithub==1.29
+pyyaml==3.12
 requests>=2.9.1,<3.0
 six
 validators

--- a/scripts/retrieve_base_ami.py
+++ b/scripts/retrieve_base_ami.py
@@ -66,7 +66,13 @@ def retrieve_base_ami(environment, deployment, play, override, out_file):
         else:
             ami_id = ec2.active_ami_for_edp(environment, deployment, play)
 
-        ami_info = {'base_ami_id': ami_id}
+        ami_info = {
+            # This is passed directly to an ansible script that expects a base_ami_id variable
+            'base_ami_id': ami_id,
+            # This matches the key produced by the create_ami.yml ansible play to make
+            # generating release pages easier.
+            'ami_id': ami_id,
+        }
         ami_info.update(ec2.tags_for_ami(ami_id))
         logging.info("Found active AMI ID for {env}-{dep}-{play}: {ami_id}".format(
             env=environment, dep=deployment, play=play, ami_id=ami_id

--- a/scripts/update_release_page.py
+++ b/scripts/update_release_page.py
@@ -1,0 +1,151 @@
+#! /usr/bin/env python3
+
+"""
+Command-line script to create or update the release page for a specific release.
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from os import path
+import sys
+import logging
+import click
+import yaml
+
+
+# Add top-level module path to sys.path before importing tubular code.
+sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+
+from tubular.confluence_api import ReleasePage, publish_page, AMI, ReleaseStatus  # pylint: disable=wrong-import-position
+from tubular.github_api import (  # pylint: disable=wrong-import-position
+    default_expected_release_date,
+)
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+LOG = logging.getLogger(__name__)
+
+EXPECTED_RELEASE_DATE = default_expected_release_date()
+
+
+@click.command()
+@click.option(
+    '-c', '--compare', 'ami_pairs',
+    help=u"A pair of paths to AMI description yaml files.",
+    type=(click.File(), click.File()),
+    multiple=True
+)
+@click.option(
+    '--confluence-url',
+    help=u"The base url of the confluence instance to publish the release page to.",
+    default='https://openedx.atlassian.net/wiki',
+)
+@click.option(
+    '--user',
+    help=u"The username of the confluence user to post as.",
+    required=True,
+)
+@click.option(
+    '--password',
+    help=u"The password for the confluence user.",
+    required=True,
+)
+@click.option(
+    '--parent-title',
+    help=u"The title of the page to publish this page as a child of.",
+)
+@click.option(
+    '--space',
+    help=u"The space to publish this page in.",
+)
+@click.option(
+    '--title',
+    help=u"The title of this page.",
+)
+@click.option(
+    '--github-token',
+    help=u"The token to use when accessing the github api.",
+    required=True,
+)
+@click.option(
+    '--jira-url',
+    help=u"The base url for the JIRA instance to link JIRA tickets to.",
+    default='https://openedx.atlassian.net'
+)
+@click.option(
+    '--gocd-url',
+    help=u"The url of the GoCD pipeline that build this release.",
+)
+@click.option(
+    '--status',
+    help=u"The current status of this deployment",
+    required=True,
+    type=click.Choice(ReleaseStatus.__members__.keys()),  # pylint: disable=no-member
+)
+@click.option(
+    '--out-file',
+    help=u"File location to export metadata that can be used to update this page.",
+    type=click.File(mode='w'),
+    default=sys.stdout,
+)
+@click.option(
+    '--in-file',
+    help=u"File location to import metadata from to specify a page to update.",
+    type=click.File(),
+)
+def create_release_page(
+        ami_pairs, confluence_url, user, password, parent_title,
+        space, title, github_token, jira_url, gocd_url, status,
+        out_file, in_file
+):
+    """
+    Create a new release page for edxapp.
+    """
+    if in_file and any([parent_title, space, title]):
+        raise click.BadOptionUsage(
+            "Either --in-file or --parent-title/--space/--title must be specified, but not both."
+        )
+
+    if in_file:
+        in_data = yaml.safe_load(in_file)
+        parent_title = in_data['parent_title']
+        space = in_data['space']
+        title = in_data['title']
+
+    if title is None:
+        title = "{:%Y-%m-%d} Release".format(EXPECTED_RELEASE_DATE)
+
+    if space is None:
+        space = 'ENG'
+
+    if parent_title is None:
+        parent_title = 'LMS/Studio Release Pages'
+
+    ami_pairs = [
+        (
+            AMI(**yaml.safe_load(old)),
+            AMI(**yaml.safe_load(new))
+        )
+        for old, new in ami_pairs
+    ]
+
+    page = ReleasePage(
+        github_token,
+        jira_url,
+        getattr(ReleaseStatus, status),
+        ami_pairs,
+        gocd_url=gocd_url,
+    )
+
+    publish_page(confluence_url, user, password, space, parent_title, title, page.format())
+
+    yaml.safe_dump({
+        'parent_title': parent_title,
+        'space': space,
+        'title': title
+    }, stream=out_file)
+
+
+if __name__ == "__main__":
+    # pylint: disable=no-value-for-parameter
+    create_release_page()

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{27,34,35}-{test,quality}
 skip_install = True
 skipsdist = True
+skip_missing_interpreters = True
 
 [testenv]
 envdir =

--- a/tubular/confluence_api.py
+++ b/tubular/confluence_api.py
@@ -1,0 +1,305 @@
+u"""
+Functions for interacting with the Confluence API and for rendering
+Confluence pages.
+"""
+from __future__ import absolute_import
+
+from collections import namedtuple
+from enum import Enum
+import logging  # pylint: disable=wrong-import-order
+import re  # pylint: disable=wrong-import-order
+
+from atlassian.confluence import Confluence  # pylint: disable=import-error
+from tubular.github_api import GitHubAPI
+
+from lxml.html import builder as E
+from lxml.html.builder import E as element_maker
+import lxml.html
+
+SECTION = element_maker.section
+VersionDelta = namedtuple(u'VersionDelta', [u'base', u'new'])
+Version = namedtuple(u'Version', [u'repo', u'sha'])
+
+GITHUB_PREFIX = re.compile(u'https?://github.com/')
+LOGGER = logging.getLogger(__name__)
+
+
+class ReleaseStatus(Enum):
+    u"""The set of valid release states."""
+    STAGED = u"Deployed to Staging"
+    DEPLOYED = u"Deployed to Production"
+    ROLLED_BACK = u"Rolled back from Production"
+
+
+class AMI(object):
+    u"""
+    An object capturing details about an AMI.
+    """
+    def __init__(self, ami_id, environment, deployment, play, **versions):
+        self.ami_id = ami_id
+        self.environment = environment
+        self.deployment = deployment
+        self.play = play
+
+        self.versions = {}
+        for key, value in versions.items():
+            if not key.startswith(u'version:'):
+                continue
+
+            _, _, app = key.partition(u':')
+            repo, _, sha = value.partition(u' ')
+            self.versions[app] = Version(convert_ssh_url(repo), sha)
+
+
+def convert_ssh_url(url):
+    u"""
+    Convert a git-url for a repository to an https url.
+    """
+    return url.replace(u'git@github.com:', u'https://github.com/').replace(u'.git', u'')
+
+
+def version_deltas(base, new):
+    u"""
+    Yields a list of VersionDelta objects for any changes between `base` and `new`.
+
+    Arguments:
+        base, new (AMI): Descriptions of a deployed AMI.
+    """
+    for app in set(base.versions) | set(new.versions):
+        base_version = base.versions.get(app)
+        new_version = new.versions.get(app)
+
+        yield VersionDelta(base_version, new_version)
+
+
+def diff(base, new):
+    u"""
+    Return an Element that renders the version differences between the amis `base` and `new`.
+
+    Arguments:
+        base, new (dicts): Descriptions of a deployed AMI. Any keys that start with
+            'version:' should have values that are a repo and a sha, separated by a space.
+            They must also have the keys 'environment', 'deployment', 'play', and 'ami_id'.
+    """
+    diff_items = []
+    for delta in sorted(set(version_deltas(base, new))):
+        version = delta.new or delta.base
+        repo = GITHUB_PREFIX.sub(u'', version.repo)
+        diff_items.append(E.LI(
+            E.STRONG(
+                E.A(
+                    u"{}: {}...{}".format(repo, delta.base.sha, delta.new.sha),
+                    href=u"{}/compare/{}...{}".format(
+                        version.repo, delta.base.sha, delta.new.sha
+                    ),
+                )
+            )
+        ))
+    return SECTION(
+        E.H3(u"Comparing {base.environment}-{base.deployment}-{base.play}: {base.ami_id} to {new.ami_id}".format(
+            base=base,
+            new=new,
+        )),
+        E.UL(*diff_items, style=u"list-style-type: square")
+    )
+
+
+def format_jira_references(jira_url, text):
+    u"""
+    Return an Element that renders links to all JIRA ticket ids found in `text`.
+
+    Arguments:
+        jira_url: The base url that the JIRA tickets should link to.
+    """
+    tickets = set(re.findall(u"\\b[A-Z]{2,}-\\d+\\b", text))
+    if tickets:
+        return SECTION(
+            *(
+                E.P(E.A(ticket, href=u"{}/browse/{}".format(jira_url, ticket)))
+                for ticket in sorted(tickets)
+            )
+        )
+    else:
+        return u""
+
+
+def pr_table(token, jira_url, delta):
+    u"""
+    Return an Element that renders all changes in `delta` as a table listing merged PRs.abs
+
+    Arguments:
+        token: The github token to access the github API with.
+        jira_url: The base url of the JIRA instance to link JIRA tickets to.
+        delta (VersionDelta): The AMIs to compare.
+    """
+    version = delta.new or delta.base
+    match = re.search(u"github.com/(?P<org>[^/]*)/(?P<repo>.*)", version.repo)
+    api = GitHubAPI(match.group(u'org'), match.group(u'repo'), token)
+
+    try:
+        prs = api.get_pr_range(delta.base.sha, delta.new.sha)
+    except Exception:  # pylint: disable=broad-except
+        LOGGER.exception(u'Unable to get PRs for %r', delta)
+        return SECTION(
+            E.H3(
+                u"Unable to list changes for {} ({}...{})".format(
+                    version.repo,
+                    delta.base.sha,
+                    delta.new.sha
+                )
+            )
+        )
+
+    return SECTION(
+        E.H3(
+            u"Changes for ",
+            E.A(
+                GITHUB_PREFIX.sub(u'', version.repo),
+                href=version.repo
+            ),
+            u" ({}...{})".format(delta.base.sha, delta.new.sha),
+        ),
+        E.TABLE(
+            E.CLASS(u"wrapped"),
+            E.TBODY(
+                E.TR(
+                    E.TH(u"Merged By"),
+                    E.TH(u"Author"),
+                    E.TH(u"Title"),
+                    E.TH(u"PR"),
+                    E.TH(u"JIRA"),
+                    E.TH(u"Release Notes?"),
+                ),
+                *(
+                    E.TR(
+                        E.TD(E.A(
+                            pull_request.merged_by.login,
+                            href=pull_request.merged_by.html_url,
+                        )),
+                        E.TD(E.A(
+                            pull_request.user.login,
+                            href=pull_request.user.html_url,
+                        )),
+                        E.TD(pull_request.title),
+                        E.TD(E.A(
+                            str(pull_request.number),
+                            href=pull_request.html_url,
+                        )),
+                        E.TD(format_jira_references(jira_url, pull_request.body)),
+                        E.TD(u""),
+                    )
+                    for pull_request in sorted(prs, key=lambda pr: pr.merged_by.login)
+                )
+            )
+        )
+    )
+
+
+class ReleasePage(object):
+    u"""
+    An object that captures and renders all of the information needed for a Release Page.
+    """
+    def __init__(
+            self, github_token, jira_url, status, ami_pairs, gocd_url=None,
+    ):
+        self.github_token = github_token
+        self.jira_url = jira_url
+        self.gocd_url = gocd_url
+        self.status = status
+        self.ami_pairs = ami_pairs
+
+    def _format_diffs(self):
+        u"""
+        Return an Element that contains formatted links to a diff between all AMI pairs.
+        """
+        return SECTION(
+            E.H2(u"Code Diffs"),
+            *(
+                diff(old, new) for (old, new) in self.ami_pairs
+            )
+        )
+
+    def _format_amis(self):
+        u"""
+        Return an Element that contains formatted description of the deployed AMIs.
+        """
+        return SECTION(
+            E.H2(u"Final AMIs"),
+            E.UL(
+                *[
+                    E.STRONG(u"{ami.environment}-{ami.deployment}-{ami.play}: {ami.ami_id}".format(ami=ami))
+                    for _, ami in self.ami_pairs
+                    if ami is not None
+                ],
+                style=u"list-style-type: square"
+            ),
+        )
+
+    def _format_changes(self):
+        u"""
+        Return an Element that contains tables with all merged PRs for each repository that changed.
+        """
+        return SECTION(
+            E.H2(u"Detailed Changes"),
+            *(
+                pr_table(self.github_token, self.jira_url, delta)
+                for delta in set().union(*(version_deltas(old, new) for (old, new) in self.ami_pairs))
+                if delta.new.sha != delta.base.sha
+            )
+        )
+
+    def _format_gocd(self):
+        u"""
+        Return an Element that links to the GoCD build pipeline.
+        """
+        if self.gocd_url:
+            return SECTION(
+                E.H2(u"GoCD Release Pipeline"),
+                E.A(self.gocd_url, href=self.gocd_url)
+            )
+        else:
+            return None
+
+    def _format_status(self):
+        u"""
+        Return an Element that renders the current release status.
+        """
+        return SECTION(
+            E.H2(u"Current Status: {}".format(self.status.value))
+        )
+
+    def format(self):
+        u"""
+        Return a formatted JIRA storage-format document representing this release.
+        """
+        content = [
+            self._format_status(),
+            self._format_gocd(),
+            self._format_diffs(),
+            self._format_amis(),
+            self._format_changes(),
+        ]
+
+        return u"\n".join(
+            lxml.html.tostring(piece, pretty_print=True, encoding=u'unicode')
+            for piece in content
+            if piece is not None
+        )
+
+
+def publish_page(url, user, password, space, parent_title, title, body):
+    u"""
+    Publish a page to Confluence.
+
+    Arguments:
+        url: The base url for the Confluence instance.
+        user: The username of the Confluence user to publish as.
+        password: The password of the Confluence user.
+        space: The space to publish the page into.
+        parent_title: The title of the page to make this page a child of.
+        title: The title of the page to create.
+        body: The storage-format contents of the page to publish.
+    """
+    conf = Confluence(url, user, password)
+    parent_page = conf.get_page_by_title(space, parent_title)
+    return conf.update_or_create(parent_page[u'id'], title, body)

--- a/tubular/tests/test_confluence_api.py
+++ b/tubular/tests/test_confluence_api.py
@@ -1,0 +1,114 @@
+"""
+Tests of tubular.confluence_api.
+"""
+
+from __future__ import absolute_import
+
+import textwrap
+
+from mock import patch, Mock
+import pytest
+
+try:
+    # Attempt to import the atlassian module to see if we can even run these tests.
+    import atlassian  # pylint: disable=unused-import
+except ImportError:
+    AMI = ReleasePage = None
+else:
+    from tubular.confluence_api import AMI, ReleasePage, ReleaseStatus
+
+
+@patch(u'tubular.confluence_api.GitHubAPI')
+@pytest.mark.skipif(AMI is None, reason=u"Tests require Confluence API")
+def test_release_page(mock_github):
+
+    mock_github().get_pr_range.return_value = [
+        Mock(
+            merged_by=Mock(login=u'user_a', html_url=u'user_html_a'),
+            user=Mock(login=u'user_c', html_url=u'user_html_c'),
+            title=u'pr a',
+            number=1,
+            html_url=u'pr_url_1',
+            body=u'lorem ipsum TE-1234 TE-4321',
+        ),
+        Mock(
+            merged_by=Mock(login=u'user_b', html_url=u'user_html_b'),
+            user=Mock(login=u'user_d', html_url=u'user_html_d'),
+            title=u'pr b',
+            number=2,
+            html_url=u'pr_url_2',
+            body=u'lorem ipsum',
+        ),
+    ]
+
+    page = ReleasePage(
+        u'github_token',
+        u'jira_url',
+        ReleaseStatus.DEPLOYED,
+        [
+            (
+                AMI(
+                    u'ami_id_1', u'env', u'depl', u'play',
+                    **{
+                        u'version:app_a': u'https://github.com/org/repo_a 12345',
+                        u'version:app_b': u'https://github.com/org/repo_b 12345',
+                    }
+                ),
+                AMI(
+                    u'ami_id_2', u'env', u'depl', u'play',
+                    **{
+                        u'version:app_a': u'git@github.com:org/repo_a.git 54321',
+                        u'version:app_b': u'git@github.com/org/repo_b.git 12345',
+                    }
+                ),
+            )
+        ],
+        gocd_url=u'gocd_url',
+    )
+
+    assert page.format() == textwrap.dedent(u"""\
+        <section><h2>Current Status: Deployed to Production</h2></section>
+
+        <section><h2>GoCD Release Pipeline</h2>
+        <a href="gocd_url">gocd_url</a></section>
+
+        <section><h2>Code Diffs</h2>
+        <section><h3>Comparing env-depl-play: ami_id_1 to ami_id_2</h3>
+        <ul style="list-style-type: square">
+        <li><strong><a href="https://github.com/org/repo_a/compare/12345...54321">org/repo_a: 12345...54321</a></strong></li>
+        <li><strong><a href="git@github.com/org/repo_b/compare/12345...12345">git@github.com/org/repo_b: 12345...12345</a></strong></li>
+        </ul></section></section>
+
+        <section><h2>Final AMIs</h2>
+        <ul style="list-style-type: square"><strong>env-depl-play: ami_id_2</strong></ul></section>
+
+        <section><h2>Detailed Changes</h2>
+        <section><h3>Changes for <a href="https://github.com/org/repo_a">org/repo_a</a> (12345...54321)</h3>
+        <table class="wrapped"><tbody>
+        <tr>
+        <th>Merged By</th>
+        <th>Author</th>
+        <th>Title</th>
+        <th>PR</th>
+        <th>JIRA</th>
+        <th>Release Notes?</th>
+        </tr>
+        <tr>
+        <td><a href="user_html_a">user_a</a></td>
+        <td><a href="user_html_c">user_c</a></td>
+        <td>pr a</td>
+        <td><a href="pr_url_1">1</a></td>
+        <td><section><p><a href="jira_url/browse/TE-1234">TE-1234</a></p>
+        <p><a href="jira_url/browse/TE-4321">TE-4321</a></p></section></td>
+        <td></td>
+        </tr>
+        <tr>
+        <td><a href="user_html_b">user_b</a></td>
+        <td><a href="user_html_d">user_d</a></td>
+        <td>pr b</td>
+        <td><a href="pr_url_2">2</a></td>
+        <td></td>
+        <td></td>
+        </tr>
+        </tbody></table></section></section>
+    """)


### PR DESCRIPTION
Accepts one or more pairs of old/new AMIs, and generates and publishes
Confluence pages.

[TE-1935]