### PR TITLE
Cale/fix sys path hacks

### DIFF
--- a/tubular/scripts/asgard_deploy.py
+++ b/tubular/scripts/asgard_deploy.py
@@ -9,16 +9,12 @@ from __future__ import unicode_literals
 from __future__ import print_function
 
 import io
-import os
 import sys
 import logging
 import time
 import traceback
 import click
 import yaml
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from tubular import asgard  # pylint: disable=wrong-import-position
 

--- a/tubular/scripts/check_migrate_duration.py
+++ b/tubular/scripts/check_migrate_duration.py
@@ -8,14 +8,10 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import io
-import os
 import sys
 import logging
 import yaml
 import click
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from tubular.email import send_email  # pylint: disable=wrong-import-position
 

--- a/tubular/scripts/check_pr_against_branch.py
+++ b/tubular/scripts/check_pr_against_branch.py
@@ -6,12 +6,8 @@ Script to check if a PR's base is the specified branch.
 from __future__ import absolute_import
 from __future__ import print_function
 
-from os import path
 import sys
 import click
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular.github_api import GitHubAPI  # pylint: disable=wrong-import-position
 

--- a/tubular/scripts/check_pr_tests_status.py
+++ b/tubular/scripts/check_pr_tests_status.py
@@ -7,14 +7,10 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import io
-from os import path
 import logging
 import sys
 import click
 import yaml
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular.github_api import GitHubAPI  # pylint: disable=wrong-import-position
 

--- a/tubular/scripts/cleanup-asgs.py
+++ b/tubular/scripts/cleanup-asgs.py
@@ -7,14 +7,10 @@ Command-line script used to delete AWS Auto-Scaling Groups that are tagged for d
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from os import path
 import sys
 import logging
 import traceback
 import click
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular import asgard  # pylint: disable=wrong-import-position
 from tubular.ec2 import get_asgs_pending_delete  # pylint: disable=wrong-import-position

--- a/tubular/scripts/create_pr.py
+++ b/tubular/scripts/create_pr.py
@@ -8,15 +8,10 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import io
-from os import path
 import sys
 import logging
 import click
 import yaml
-
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular.github_api import GitHubAPI  # pylint: disable=wrong-import-position
 from github.GithubException import GithubException  # pylint: disable=wrong-import-position

--- a/tubular/scripts/create_release_candidate.py
+++ b/tubular/scripts/create_release_candidate.py
@@ -7,16 +7,11 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import io
-from os import path
 import sys
 import logging
 import datetime
 import click
 import yaml
-
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular.github_api import (  # pylint: disable=wrong-import-position
     GitHubAPI,

--- a/tubular/scripts/create_tag.py
+++ b/tubular/scripts/create_tag.py
@@ -7,17 +7,12 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import io
-from os import path
 import sys
 import logging
 import datetime
 import yaml
 from pytz import timezone
 import click
-
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular.github_api import GitHubAPI  # pylint: disable=wrong-import-position
 from tubular.utils import exactly_one_set  # pylint: disable=wrong-import-position

--- a/tubular/scripts/cut_branch.py
+++ b/tubular/scripts/cut_branch.py
@@ -7,14 +7,10 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import io
-from os import path
 import sys
 import logging
 import click
 import yaml
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular.github_api import (  # pylint: disable=wrong-import-position
     GitHubAPI,

--- a/tubular/scripts/delete_asg.py
+++ b/tubular/scripts/delete_asg.py
@@ -7,14 +7,10 @@ Command-line script used to delete a specified Auto-Scaling Group via Asgard.
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from os import path
 import sys
 import logging
 import traceback
 import click
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular import asgard  # pylint: disable=wrong-import-position
 

--- a/tubular/scripts/drupal_backup_database.py
+++ b/tubular/scripts/drupal_backup_database.py
@@ -6,12 +6,7 @@ Command-line script to create a database backup in an environment.
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import sys
-from os import path
 import click
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular import drupal  # pylint: disable=wrong-import-position
 

--- a/tubular/scripts/drupal_clear_varnish.py
+++ b/tubular/scripts/drupal_clear_varnish.py
@@ -6,12 +6,7 @@ Command-line script to clear the Varnish cache for an environment.
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import sys
-from os import path
 import click
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular import drupal  # pylint: disable=wrong-import-position
 

--- a/tubular/scripts/drupal_deploy.py
+++ b/tubular/scripts/drupal_deploy.py
@@ -6,12 +6,7 @@ Command-line script to deploy a Drupal release.
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import sys
-from os import path
 import click
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular import drupal  # pylint: disable=wrong-import-position
 

--- a/tubular/scripts/drupal_fetch_deployed_tag.py
+++ b/tubular/scripts/drupal_fetch_deployed_tag.py
@@ -6,12 +6,7 @@ Command-line script to fetch a deployed Drupal tag.
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import sys
-from os import path
 import click
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular import drupal  # pylint: disable=wrong-import-position
 

--- a/tubular/scripts/jenkins_trigger_build.py
+++ b/tubular/scripts/jenkins_trigger_build.py
@@ -4,15 +4,10 @@
 Command-line script to trigger a jenkins job
 """
 from __future__ import absolute_import
-from os import path
-import sys
 
 import click
 import click_log
 from jenkinsapi.constants import STATUS_FAIL, STATUS_ERROR, STATUS_ABORTED, STATUS_REGRESSION, STATUS_SUCCESS
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular import jenkins  # pylint: disable=wrong-import-position
 

--- a/tubular/scripts/merge_branch.py
+++ b/tubular/scripts/merge_branch.py
@@ -6,14 +6,10 @@ Command-line script to merge a branch.
 from __future__ import absolute_import
 
 import io
-from os import path
 import sys
 import logging
 import yaml
 import click
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular.git_repo import merge_branch as merge_repo_branch  # pylint: disable=wrong-import-position
 

--- a/tubular/scripts/merge_pr.py
+++ b/tubular/scripts/merge_pr.py
@@ -7,14 +7,10 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import io
-from os import path
 import sys
 import logging
 import click
 import yaml
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular.github_api import GitHubAPI  # pylint: disable=wrong-import-position
 from github.GithubException import GithubException, UnknownObjectException  # pylint: disable=wrong-import-position

--- a/tubular/scripts/message_prs_in_range.py
+++ b/tubular/scripts/message_prs_in_range.py
@@ -4,14 +4,10 @@
 Command-line script message pull requests in a range
 """
 from __future__ import absolute_import
-from os import path
 import sys
 import logging
 import click
 import yaml
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular.github_api import GitHubAPI  # pylint: disable=wrong-import-position
 

--- a/tubular/scripts/poll_pr_tests_status.py
+++ b/tubular/scripts/poll_pr_tests_status.py
@@ -7,14 +7,10 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import io
-from os import path
 import logging
 import sys
 import click
 import yaml
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular.github_api import GitHubAPI  # pylint: disable=wrong-import-position
 from tubular.utils import exactly_one_set  # pylint: disable=wrong-import-position

--- a/tubular/scripts/restrict_to_stage.py
+++ b/tubular/scripts/restrict_to_stage.py
@@ -6,14 +6,10 @@ Command-line script to allow only AMI deployments to stage - and no other enviro
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from os import path
 import sys
 import logging
 import traceback
 import click
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular.ec2 import is_stage_ami  # pylint: disable=wrong-import-position
 

--- a/tubular/scripts/retrieve_base_ami.py
+++ b/tubular/scripts/retrieve_base_ami.py
@@ -8,16 +8,12 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
-from os import path
 import io
 import sys
 import logging
 import traceback
 import click
 import yaml
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular import ec2  # pylint: disable=wrong-import-position
 

--- a/tubular/scripts/rollback_asg.py
+++ b/tubular/scripts/rollback_asg.py
@@ -8,15 +8,11 @@ from __future__ import unicode_literals
 from __future__ import print_function
 
 import io
-from os import path
 import sys
 import logging
 import traceback
 import click
 import yaml
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular import asgard  # pylint: disable=wrong-import-position
 

--- a/tubular/scripts/update_release_page.py
+++ b/tubular/scripts/update_release_page.py
@@ -7,15 +7,10 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from os import path
 import sys
 import logging
 import click
 import yaml
-
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular.confluence_api import ReleasePage, publish_page, AMI, ReleaseStatus  # pylint: disable=wrong-import-position
 from tubular.github_api import (  # pylint: disable=wrong-import-position

--- a/tubular/scripts/validate_edp.py
+++ b/tubular/scripts/validate_edp.py
@@ -6,14 +6,10 @@ Command-line script to validate that an AMI was built for a particular EDP.
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from os import path
 import sys
 import logging
 import traceback
 import click
-
-# Add top-level module path to sys.path before importing tubular code.
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular.ec2 import validate_edp  # pylint: disable=wrong-import-position
 


### PR DESCRIPTION
This depends on #123. It also requires that we go through edx/edx-gomatic and scrub any references to `script/some_script.py` before merging it.