### PR TITLE
Poll jenkins every minute when waiting for updates on tests

### DIFF
--- a/tubular/jenkins.py
+++ b/tubular/jenkins.py
@@ -104,11 +104,10 @@ def trigger_build(base_url, user_name, user_token, job_name, job_token,
     Raises:
         BackendError: if the Jenkins job could not be triggered successfully
     """
-    wait_gen, max_tries = _backoff_timeout(timeout)
-
     @backoff.on_predicate(
-        wait_gen,
-        max_tries=max_tries,
+        backoff.constant,
+        interval=60,
+        max_tries=timeout / 60 + 1,
         on_giveup=_poll_giveup,
         # We aren't worried about concurrent access, so turn off jitter
         jitter=None,


### PR DESCRIPTION
This means that we will never wait more than a minute longer than it
takes the tests to actually run (unlike the exponential backoff
algorithm, which could potentially lead to much longer task runtimes).