### PR TITLE
Use a sequence not a generator for *args

### DIFF
--- a/tubular/confluence_api.py
+++ b/tubular/confluence_api.py
@@ -243,7 +243,7 @@ class ReleasePage(object):
             E.H2(u"Detailed Changes"),
             *(
                 pr_table(self.github_token, self.jira_url, delta)
-                for delta in set().union(*(version_deltas(old, new) for (old, new) in self.ami_pairs))
+                for delta in set().union(*[version_deltas(old, new) for (old, new) in self.ami_pairs])
                 if delta.new.sha != delta.base.sha
             )
         )

--- a/tubular/confluence_api.py
+++ b/tubular/confluence_api.py
@@ -214,9 +214,9 @@ class ReleasePage(object):
         """
         return SECTION(
             E.H2(u"Code Diffs"),
-            *(
+            *[
                 diff(old, new) for (old, new) in self.ami_pairs
-            )
+            ]
         )
 
     def _format_amis(self):
@@ -241,11 +241,11 @@ class ReleasePage(object):
         """
         return SECTION(
             E.H2(u"Detailed Changes"),
-            *(
+            *[
                 pr_table(self.github_token, self.jira_url, delta)
                 for delta in set().union(*[version_deltas(old, new) for (old, new) in self.ami_pairs])
                 if delta.new.sha != delta.base.sha
-            )
+            ]
         )
 
     def _format_gocd(self):


### PR DESCRIPTION
Should fix https://gocd.tools.edx.org/go/tab/build/detail/STAGE_edxapp_M-D/101/message_pr_stage/1/publish_wiki_job. Not sure why it wasn't flagged in tests.