### PR TITLE
Upon socket.timeout, retry and continue to poll.

### DIFF
--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -5,6 +5,7 @@ from __future__ import print_function, unicode_literals
 from datetime import datetime, timedelta, time
 import logging
 import os
+import socket
 import backoff
 
 from tubular.exception import InvalidUrlException
@@ -247,6 +248,11 @@ class GitHubAPI(object):
             self.get_head_commit_from_pull_request(pr_number)
         ).state.lower() == 'success'
 
+    @backoff.on_exception(
+        backoff.expo,
+        socket.timeout,
+        max_tries=5
+    )
     @backoff.on_predicate(
         _constant_with_initial_wait,
         lambda x: x not in ('success', 'failure'),


### PR DESCRIPTION
Saw a socket timeout in this branch-merging run:
https://gocd.tools.edx.org/go/tab/build/detail/edxapp_branch_cleanup/43/check_pr_tests_and_merg
e/1/check_pr_tests_and_merge_job

Added code to handle socket timeouts with a retry.

@edx/pipeline-team @cpennington Please review.