### PR TITLE
Fix git tag fetching when tag is already created.

### DIFF
--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -508,12 +508,12 @@ class GitHubAPI(object):
             if exc.status != 422:
                 raise
             # Tag is already created. Verify it's on the correct hash.
-            existing_tag = self.github_repo.get_git_tag(tag_name)
-            if existing_tag.sha != sha:
+            existing_tag = self.github_repo.get_git_ref('tags/{}'.format(tag_name))
+            if existing_tag.object.sha != sha:
                 # The tag is already created and pointed to a different SHA than requested.
                 raise GitTagMismatchError(
                     "Tag '{}' exists but points to SHA {} instead of requested SHA {}.".format(
-                        tag_name, existing_tag.sha, sha
+                        tag_name, existing_tag.object.sha, sha
                     )
                 )
         return created_tag

--- a/tubular/tests/test_github.py
+++ b/tubular/tests/test_github.py
@@ -207,8 +207,8 @@ class GitHubApiTestCase(TestCase):
         self.repo_mock.create_git_ref = Mock(
             side_effect=GithubException(status_code, {'message': msg})
         )
-        self.repo_mock.get_git_tag = get_tag_mock = Mock()
-        get_tag_mock.return_value = Mock(sha=return_sha)
+        self.repo_mock.get_git_ref = get_tag_mock = Mock()
+        get_tag_mock.return_value = Mock(object=Mock(sha=return_sha))
         return mock_user
 
     def test_create_tag_which_already_exists_but_matches_sha(self):


### PR DESCRIPTION
Should fix this error:
https://gocd.tools.edx.org/go/tab/build/detail/edxapp_branch_cleanup/55/merge_rc_branch/1/tag_deployed_commit_job

@edx/pipeline-team @cpennington PTAL.