### PR TITLE
Scripts to merge private merged changes into public repo (and back).

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 atlassian-python-api==0.13.2; python_version >= '3.2'
-enum34 >=1.1.6, <2.0; python_version < '3.4'
 backoff>=1.3.2,<1.4.0
 boto==2.43.0
 click>=6.2,<7.0
 click-log==0.1.8
+enum34 >=1.1.6, <2.0; python_version < '3.4'
+freezegun==0.3.8
 GitPython==2.1.1
 jenkinsapi==0.3.3
 lxml >= 3.7, <3.8
@@ -14,4 +15,3 @@ requests>=2.9.1,<3.0
 six
 validators
 yagocd==0.4.4
-freezegun==0.3.8

--- a/scripts/create_private_to_public_pr.py
+++ b/scripts/create_private_to_public_pr.py
@@ -1,0 +1,1 @@
+../tubular/scripts/create_private_to_public_pr.py

--- a/scripts/push_public_to_private.py
+++ b/scripts/push_public_to_private.py
@@ -1,0 +1,1 @@
+../tubular/scripts/push_public_to_private.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ console_scripts =
     cleanup-asgs.py = tubular.scripts.cleanup_asgs:delete_asg
     cleanup_instances.py = tubular.scripts.cleanup_instances:terminate_instances
     create_pr.py = tubular.scripts.create_pr:create_pull_request
+    create_public_to_private_pr.py = tubular.scripts.create_public_to_private_pr:create_public_to_private_pr
     create_release_candidate.py = tubular.scripts.create_release_candidate:create_release_candidate
     create_tag.py = tubular.scripts.create_tag:create_tag
     cut_branch.py = tubular.scripts.cut_branch:create_release_candidate
@@ -36,6 +37,7 @@ console_scripts =
     merge_pr.py = tubular.scripts.merge_pr:merge_pull_request
     message_prs_in_range.py = tubular.scripts.message_prs_in_range:message_pull_requests
     poll_pr_tests_status.py = tubular.scripts.poll_pr_tests_status:poll_tests
+    push_public_to_private.py = tubular.scripts.push_public_to_private:push_public_to_private
     restrict_to_stage.py = tubular.scripts.restrict_to_stage:restrict_ami_to_stage
     retrieve_base_ami.py = tubular.scripts.retrieve_base_ami:retrieve_base_ami
     rollback_asg.py = tubular.scripts.rollback_asg:rollback
@@ -45,15 +47,16 @@ console_scripts =
 
 [extras]
 test =
+    astroid==1.4.9
     ddt==1.0.1
     edx_lint
     moto==0.4.30
     mock==2.0.0
     pep8==1.7.0
-    pylint
+    pylint==1.6.3
     pytest==3.0.5
     pytest-xdist==1.15.0
-    pytest-pylint
+    pytest-pylint==0.7.0
     pytest-pep8
     responses==0.5.0
     requests_mock

--- a/tubular/git_repo.py
+++ b/tubular/git_repo.py
@@ -176,12 +176,11 @@ class LocalGitAPI(object):
             self.repo.heads[branch].reset(commitish, index=True)
 
     @contextmanager
-    def cleanup(self, cleanup=True):
+    def cleanup(self):
         """
         Delete the repo working directory when this contextmanager is finished.
         """
         try:
             yield self
         finally:
-            if cleanup:
-                rmtree(self.repo.working_dir)
+            rmtree(self.repo.working_dir)

--- a/tubular/scripts/create_pr.py
+++ b/tubular/scripts/create_pr.py
@@ -18,8 +18,7 @@ import yaml
 # Add top-level module path to sys.path before importing tubular code.
 sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
-from tubular.github_api import GitHubAPI  # pylint: disable=wrong-import-position
-from github.GithubException import GithubException  # pylint: disable=wrong-import-position
+from tubular.github_api import GitHubAPI, PullRequestCreationError  # pylint: disable=wrong-import-position
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 LOG = logging.getLogger(__name__)
@@ -75,37 +74,8 @@ def create_pull_request(org,
                         output_file):
     """
     Creates a pull request to merge a source branch into a target branch, if needed.
-    Both the source and target branches are assumed to already exist.
-
-    Args:
-        org (str):
-        repo (str):
-        token (str):
-        source_branch (str):
-        target_branch (str):
-        title (str):
-        body (str):
-        output_file (str):
-
-    Outputs a yaml file with information about the newly created PR:
-     ---
-    pr_created: true
-    pr_id: 96786312
-    pr_number: 3
-    pr_url: https://api.github.com/repos/macdiesel412/Rainer/pulls/3
-    pr_repo_url: /repos/macdiesel412/Rainer
-    pr_head: af538da6b229cf1dfa33d0171e75fbff6de4c283
-    pr_base: 2a800083658e2f5d11d1d40118024f77c59d1b9a
-    pr_diff_url: https://github.com/macdiesel412/Rainer/pull/3.diff
-    pr_mergable: null
-    pr_state: open
-    pr_mergable_state: unknown
-
-    -or-
-     ---
-    pr_created: false
-
-    if no PR is required.
+    Both the source and target branches are assumed to already exist. Outputs a YAML
+    file with information about the PR creation.
     """
     github_api = GitHubAPI(org, repo, token)
 
@@ -143,7 +113,7 @@ def create_pull_request(org,
                 title=title,
                 body=body
             )
-        except GithubException:
+        except PullRequestCreationError:
             LOG.error("Unable to create pull request. Aborting")
             raise
 

--- a/tubular/scripts/create_private_to_public_pr.py
+++ b/tubular/scripts/create_private_to_public_pr.py
@@ -1,0 +1,162 @@
+#! /usr/bin/env python3
+
+"""
+Command-line script to create a PR moving any merged changes from a tracking branch in a private repo
+into a branch being tracked in a public repo. Used to automate the merging of security fixes from a
+private repo into a public repo.
+"""
+from __future__ import absolute_import
+
+import io
+from os import path
+import sys
+import logging
+import yaml
+import click
+import click_log
+
+# Add top-level module path to sys.path before importing tubular code.
+sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+
+from tubular.git_repo import LocalGitAPI  # pylint: disable=wrong-import-position
+from tubular.github_api import GitHubAPI, PullRequestCreationError  # pylint: disable=wrong-import-position
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+LOG = logging.getLogger(__name__)
+
+
+@click.command()
+@click.option(
+    u'--private_org',
+    help=u'Org from the private GitHub repository URL of https://github.com/<org>/<repo>',
+    default=u'edx'
+)
+@click.option(
+    u'--private_repo',
+    help=u'Repo name from the private GitHub repository URL of https://github.com/<org>/<repo>'
+)
+@click.option(
+    u'--private_source_branch',
+    help=u'Source branch from the private repo to be merged into the target branch of the public repo in the PR.',
+    required=True
+)
+@click.option(
+    u'--public_org',
+    help=u'Org from the public GitHub repository URL of https://github.com/<org>/<repo>',
+    default=u'edx'
+)
+@click.option(
+    u'--public_repo',
+    help=u'Repo name from the public GitHub repository URL of https://github.com/<org>/<repo>'
+)
+@click.option(
+    u'--public_target_branch',
+    help=u'Target base branch from the public repo into which the private source branch will be merged in the PR.',
+    required=True
+)
+@click.option(
+    '--token',
+    envvar='GIT_TOKEN',
+    help='The github access token, see https://help.github.com/articles/creating-an-access-token-for-command-line-use/'
+)
+@click.option(
+    u'--output_file',
+    help=u'File in which to write the script\'s YAML output',
+)
+@click.option(
+    u'--reference_repo',
+    help=u'Path to a reference private repo to use to speed up repo cloning.',
+)
+@click_log.simple_verbosity_option(default=u'INFO')
+@click_log.init()
+def create_public_to_private_pr(private_org,
+                                private_repo,
+                                private_source_branch,
+                                public_org,
+                                public_repo,
+                                public_target_branch,
+                                token,
+                                output_file,
+                                reference_repo):
+    u"""
+    Creates a PR to merge the private source branch into the public target branch.
+    Clones the repo in order to perform the proper git commands locally.
+    """
+    public_github_url = u'git@github.com:{}/{}.git'.format(public_org, public_repo)
+    private_github_url = u'git@github.com:{}/{}.git'.format(private_org, private_repo)
+    output_yaml = {
+        u'private_github_url': private_github_url,
+        u'private_source_branch_name': private_source_branch,
+        u'public_github_url': public_github_url,
+        u'public_target_branch_name': public_target_branch
+    }
+
+    LOG.info('Cloning private repo %s with branch %s.', private_github_url, private_source_branch)
+    with LocalGitAPI.clone(private_github_url, private_source_branch, reference_repo).cleanup() as local_repo:
+        # Add the public repo as a remote for the private git working tree.
+        local_repo.add_remote('public', public_github_url)
+        # Create a new public branch with unique name.
+        new_branch_name = 'private_to_public_{}'.format(local_repo.get_head_sha()[:7])
+        # Push the private branch into the public repo.
+        LOG.info(
+            'Pushing private branch %s to public repo %s as branch %s.',
+            private_source_branch, public_github_url, new_branch_name
+        )
+        local_repo.push_branch(private_source_branch, 'public', new_branch_name)
+        github_api = GitHubAPI(public_org, public_repo, token)
+        # Create a PR from new public branch to public master.
+        try:
+            pull_request = github_api.create_pull_request(
+                title='Mergeback PR from private to public.',
+                body='Merge private changes back to the public repo post-PR-merge.\n\n'
+                     'Please review and tag appropriate parties.',
+                head=new_branch_name,
+                base=public_target_branch
+            )
+        except PullRequestCreationError as exc:
+            LOG.info(
+                "No pull request created for merging %s into %s in '%s' repo - nothing to merge: %s",
+                new_branch_name,
+                public_target_branch,
+                public_github_url,
+                exc
+            )
+            output_yaml.update({
+                'pr_created': False,
+            })
+            # Cleanup - delete the pushed branch.
+            github_api.delete_branch(new_branch_name)
+        else:
+            LOG.info('Created PR #%s for repo %s: %s', pull_request.number, public_github_url, pull_request.html_url)
+            output_yaml.update({
+                'pr_created': True,
+                'pr_id': pull_request.id,
+                'pr_number': pull_request.number,
+                'pr_url': pull_request.url,
+                'pr_repo_url': github_api.github_repo.url,
+                'pr_head': pull_request.head.sha,
+                'pr_base': pull_request.base.sha,
+                'pr_html_url': pull_request.html_url,
+                'pr_diff_url': pull_request.diff_url,
+                'pr_mergable': pull_request.mergeable,
+                'pr_state': pull_request.state,
+                'pr_mergable_state': pull_request.mergeable_state,
+            })
+
+    if output_file:
+        with io.open(output_file, u'w') as stream:
+            yaml.safe_dump(
+                output_yaml,
+                stream,
+                default_flow_style=False,
+                explicit_start=True
+            )
+    else:
+        yaml.safe_dump(
+            output_yaml,
+            sys.stdout,
+        )
+
+
+if __name__ == u"__main__":
+    create_public_to_private_pr()  # pylint: disable=no-value-for-parameter

--- a/tubular/scripts/push_public_to_private.py
+++ b/tubular/scripts/push_public_to_private.py
@@ -1,0 +1,119 @@
+#! /usr/bin/env python3
+
+"""
+Command-line script to push the results of a merge of private changes to public back over to the private
+repo to keep the repo branches in-sync.
+"""
+from __future__ import absolute_import
+
+import io
+from os import path
+import sys
+import logging
+import yaml
+import click
+import click_log
+
+# Add top-level module path to sys.path before importing tubular code.
+sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+
+from tubular.git_repo import LocalGitAPI  # pylint: disable=wrong-import-position
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+LOG = logging.getLogger(__name__)
+
+
+@click.command()
+@click.option(
+    u'--private_org',
+    help=u'Org from the private GitHub repository URL of https://github.com/<org>/<repo>',
+    default=u'edx'
+)
+@click.option(
+    u'--private_repo',
+    help=u'Repo name from the private GitHub repository URL of https://github.com/<org>/<repo>'
+)
+@click.option(
+    u'--private_target_branch',
+    help=u'Target branch from the private repo onto which the public source branch will be pushed.',
+    required=True
+)
+@click.option(
+    u'--public_org',
+    help=u'Org from the public GitHub repository URL of https://github.com/<org>/<repo>',
+    default=u'edx'
+)
+@click.option(
+    u'--public_repo',
+    help=u'Repo name from the public GitHub repository URL of https://github.com/<org>/<repo>'
+)
+@click.option(
+    u'--public_source_branch',
+    help=u'Source branch from the public repo to be pushed onto the target branch of the private repo.',
+    required=True
+)
+@click.option(
+    u'--output_file',
+    help=u'File in which to write the script\'s YAML output',
+)
+@click.option(
+    u'--reference_repo',
+    help=u'Path to a public reference repo to use to speed up cloning.',
+)
+@click_log.simple_verbosity_option(default=u'INFO')
+@click_log.init()
+def push_public_to_private(private_org,
+                           private_repo,
+                           private_target_branch,
+                           public_org,
+                           public_repo,
+                           public_source_branch,
+                           output_file,
+                           reference_repo):
+    u"""
+    Push the results of a merge of private changes to public back over to the private
+    repo to keep the repo branches in-sync.
+    """
+    public_github_url = u'git@github.com:{}/{}.git'.format(public_org, public_repo)
+    private_github_url = u'git@github.com:{}/{}.git'.format(private_org, private_repo)
+    output_yaml = {
+        u'private_github_url': private_github_url,
+        u'private_target_branch_name': private_target_branch,
+        u'public_github_url': public_github_url,
+        u'public_target_branch_name': public_source_branch
+    }
+
+    # Clone the public repo, checking out the proper public branch.
+    LOG.info('Cloning public repo %s with branch %s.', public_github_url, public_source_branch)
+    with LocalGitAPI.clone(public_github_url, public_source_branch, reference_repo).cleanup() as local_repo:
+        # Add the private repo as a remote for the public git working tree.
+        local_repo.add_remote('private', private_github_url)
+        try:
+            # Push the public branch back to the private branch - without forcing.
+            local_repo.push_branch(public_source_branch, 'private', private_target_branch, force=False)
+            output_yaml.update({u'branch_pushed': True})
+        except Exception as exc:  # pylint: disable=broad-except
+            # On any failure besides auth, simply log and ignore.
+            # The problem will work itself out in the next private->public cycle.
+            LOG.warning(
+                "Failed to push public branch %s to private branch %s without fast-forward: %s",
+                public_source_branch, private_target_branch, exc
+            )
+            output_yaml.update({u'branch_pushed': False})
+
+    if output_file:
+        with io.open(output_file, u'w') as stream:
+            yaml.safe_dump(
+                output_yaml,
+                stream,
+                default_flow_style=False,
+                explicit_start=True
+            )
+    else:
+        yaml.safe_dump(
+            output_yaml,
+            sys.stdout,
+        )
+
+if __name__ == u"__main__":
+    push_public_to_private()  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
These two scripts will be used to:
- create a PR to merge any newly merged changes from the private repo over to the public repo
- push the merged public changes back over to the private repo to prepare for the next cycle