### PR TITLE
[WIP] SplitMongo Pruning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+.vscode
 env/
 build/
 develop-eggs/

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ GitPython==2.1.1
 jenkinsapi==0.3.3
 lxml >= 3.7, <3.8
 PyGithub==1.29
+pymongo==3.5.0
 pytz==2016.10
 pyyaml==3.12
 requests>=2.9.1,<3.0

--- a/scripts/prune_modulestore.py
+++ b/scripts/prune_modulestore.py
@@ -1,0 +1,1 @@
+../tubular/scripts/prune_modulestore.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ console_scripts =
     merge_pr.py = tubular.scripts.merge_pr:merge_pull_request
     message_prs_in_range.py = tubular.scripts.message_prs_in_range:message_pull_requests
     poll_pr_tests_status.py = tubular.scripts.poll_pr_tests_status:poll_tests
+    prune_modulestore.py = tubular.scripts.prune_modulestore:prune_modulestore
     push_public_to_private.py = tubular.scripts.push_public_to_private:push_public_to_private
     restrict_to_stage.py = tubular.scripts.restrict_to_stage:restrict_ami_to_stage
     retrieve_base_ami.py = tubular.scripts.retrieve_base_ami:retrieve_base_ami

--- a/tubular/modulestore.py
+++ b/tubular/modulestore.py
@@ -124,14 +124,7 @@ class ModuleStore(object):
 
         """
 
-        pruned_structures = []
-
-        for structure_doc in structures:
-
-            if structure_doc['_id'] not in structures_to_remove:
-                pruned_structures.append(structure_doc)
-
-        return pruned_structures
+        return [structure_doc for structure_doc in structures if structure_doc['_id'] not in structures_to_remove]
 
     def load_test_dataset(self, dataset_file):
 
@@ -148,7 +141,6 @@ class ModuleStore(object):
         # check if the specified file exists
         file_exists = os.path.isfile(dataset_file)
 
-        assert isinstance(file_exists, object)
         if not file_exists:
             raise IOError("The specified file doesn't exist: %s", dataset_file)
 
@@ -187,10 +179,8 @@ class ModuleStore(object):
 
         """
 
-        av_filter = {'$in': []}
-
-        for active_version_id in active_version_id_list.split(","):
-            av_filter['$in'].append(ObjectId(active_version_id.strip()))
+        filter_list = [ObjectId(active_version_id.strip()) for active_version_id in active_version_id_list.split(",")]
+        av_filter = {'$in': filter_list}
 
         # establish the query filter (respecting cases where no value is specified)
         return self.get_query_filter(av_filter)
@@ -211,15 +201,8 @@ class ModuleStore(object):
 
             # check for unknown versions
             unknown_versions = [
-                version
-                for
-                version
-                in
-                active_version['versions']
-                if
-                version
-                not in
-                self.target_active_versions_keys
+                version for version in active_version['versions']
+                if version not in self.target_active_versions_keys
             ]
 
             if unknown_versions:
@@ -455,9 +438,7 @@ class ModuleStore(object):
             self.log(message_template % (version_retention, self._minimum_version_retention), "info")
 
         # iterate the active versions and build the associated version tree
-        for active_version in active_versions:
-
-            counter += 1
+        for counter, active_version in enumerate(active_versions, start=1):
 
             for target_key in self.target_active_versions_keys:
 

--- a/tubular/modulestore.py
+++ b/tubular/modulestore.py
@@ -1,0 +1,409 @@
+"""
+A collection of functions related to pruning the openedx mongo structures
+"""
+
+import json
+import os
+
+from bson.objectid import ObjectId
+from pymongo import MongoClient
+
+
+class ModuleStore(object):
+    """
+    Handles pruning operations for the edx module store structues
+    """
+
+    # the dictionary keys to track for active versions
+    target_active_versions_keys = [u'library', u'draft-branch', u'published-branch']
+
+    def __init__(self, logger=None):
+
+        # get reference to the user-specified python logger that has alreadt been initialized
+        self.logger = logger
+        self.db = None
+
+    def initialize_database_connection(self, mongo_database_connection=None, mongo_database_name="edxapp"):
+
+        """
+        Initialize database connection
+        """
+
+        if mongo_database_connection is None:
+            client = MongoClient()
+        else:
+            client = MongoClient(mongo_database_connection)
+
+        self.db = client[mongo_database_name]
+
+    def log(self, message, message_type="info"):
+
+        """
+        Log a message
+        """
+
+        if self.logger is not None:
+            if message_type == "info":
+                self.logger.info(message)
+            else:
+                self.logger.debug(message)
+
+    def save_data_file(self, data, output_file):
+
+        """
+        Save the specified data file to disk
+        """
+
+        self.log("Saving the purged dataset to {0}".format(output_file))
+
+        # write the updated dataset
+        with open(output_file, 'w') as outfile:
+            json.dump(data, outfile)
+
+    def prune_structures_static_data(self, original_dataset, structures_to_remove):
+
+        """
+        Prune the static test data and return the results
+        """
+
+        pruned_static_data = []
+
+        for structure_doc in original_dataset[u'structures']:
+
+            if structure_doc[u'_id'] not in structures_to_remove:
+                pruned_static_data.append(structure_doc)
+
+        original_dataset[u'structures'] = pruned_static_data
+
+        return original_dataset
+
+    def load_test_dataset(self, dataset_file):
+
+        """
+        Load the json dataset from the file specified
+        """
+
+        # check if the specified file exists
+        file_exists = os.path.isfile(dataset_file)
+
+        assert isinstance(file_exists, object)
+        if not file_exists:
+            raise IOError("The specified file doesn't exist: {0}".format(dataset_file))
+
+        # load the file
+        with open(dataset_file) as dataset:
+            data = json.load(dataset)
+
+        return data
+
+    def get_query_filter(self, doc_filter):
+
+        """
+        Generate a document filter for bulk querying
+        """
+
+        # establish the query filter  (respecting cases where no value is specified)
+        query_filter = None
+
+        if len(doc_filter['$in']) > 0:
+            query_filter = {"_id": doc_filter}
+
+        return query_filter
+
+    def get_active_version_filter(self, active_version_id_list):
+
+        """
+        Generate document filter for bulk querying the active version collection
+        """
+
+        av_filter = {'$in': []}
+
+        for active_version_id in active_version_id_list.split(","):
+            av_filter['$in'].append(ObjectId(active_version_id.strip()))
+
+        # establish the query filter  (respecting cases where no value is specified)
+        return self.get_query_filter(av_filter)
+
+    def get_structures_filter(self, active_version_list):
+
+        """
+        Generate document filter for bulk querying the structures collection
+        """
+
+        structure_filter = {'$in': []}
+
+        for active_version in active_version_list:
+
+            for target_key in self.target_active_versions_keys:
+                if target_key in active_version['versions']:
+                    structure_filter['$in'].append(ObjectId(active_version['versions'][target_key]))
+
+        # establish the query filter  (respecting cases where no value is specified)
+        return self.get_query_filter(structure_filter)
+
+    def get_active_versions(self, active_version_list=None):
+
+        """
+        Get all documents from the active_versions collection
+        """
+
+        # establish the active version filter (if required)
+        active_version_filter = None
+
+        if active_version_list is not None:
+            active_version_filter = self.get_active_version_filter(active_version_list)
+
+        fields = {
+            "versions.draft-branch": 1,
+            "versions.published-branch": 1,
+            "versions.library": 1,
+        }
+
+        # initialize our active versions dictionary
+        active_versions = []
+
+        # TODO: apply filters here in support of a user limiting the pruning operation to 1+ course/active versions
+        if active_version_filter is None:
+            resultset = self.db.modulestore.active_versions.find({}, fields)
+        else:
+            resultset = self.db.modulestore.active_versions.find(active_version_filter, fields)
+
+        for active_version_doc in resultset:
+
+            # collect all interesting docs: library & [draft|published]-branch active versions
+            avdocs_versions = active_version_doc['versions']
+
+            if u'library' in avdocs_versions \
+                    or u'draft-branch' in avdocs_versions \
+                    or u'published-branch' in avdocs_versions:
+                active_versions.append(active_version_doc)
+
+        # return the active versions
+        return active_versions
+
+    def get_structures(self, filter_enabled, active_versions_list):
+
+        """
+        Get all documents from the structures collection
+        """
+
+        # use filters (if required)
+        structure_filter = None
+        if filter_enabled:
+            structure_filter = self.get_structures_filter(active_versions_list)
+
+        fields = {
+            "_id": 1,
+            "previous_version": 1,
+            "original_version": 1
+        }
+
+        structures_list = []
+
+        # TODO: apply filters to support limiting the pruning operation to 1 or more courses / active versions
+        if structure_filter is None:
+            resultset = self.db.modulestore.structures.find({}, fields)
+        else:
+            resultset = self.db.modulestore.structures.find(structure_filter, fields)
+
+        for structure_doc in resultset:
+            # Get a list of all structures (or those relevant to the active versions via specified filter)
+            # this will give the list of Dictionary's with _id and previous_version
+            structures_list.append(structure_doc)
+
+        return structures_list
+
+    def prune_structures(self, structures_to_remove):
+
+        """
+        Prune the specified documents from the structures collection
+        """
+
+        # TODO: (performance): chunk up the removals to minimize possible production impact
+        if len(structures_to_remove) == 0:
+            return
+
+        structures_removal_filter = {'$in': []}
+
+        for structure_objectid_str in structures_to_remove:
+            structures_removal_filter['$in'].append(ObjectId(structure_objectid_str))
+
+        return self.db.modulestore.structures.remove({'_id': structures_removal_filter})
+
+    def relink(self, structures):
+
+        """
+        Relink structures to their original version post pruning
+        """
+
+        self.log("Relinking structures to their original versions")
+
+        index_position = 0
+        available_ids = []
+
+        # build a list of all available ids
+        available_ids.extend([structure_doc['_id'] for structure_doc in structures])
+
+        # iterate structures and relink to original
+        for structure_doc in structures:
+
+            if structure_doc["previous_version"] is not None and structure_doc["previous_version"] not in available_ids:
+
+                self.log("{0} was not found in {1}".format(structure_doc["previous_version"], available_ids), "debug")
+
+                to_be_linked_version_id = []
+                original_version_id = []
+
+                to_be_linked_version_id.append(structure_doc['_id'])
+                original_version_id.append(structure_doc['original_version'])
+
+                self.log("{0} version is being linked to {1}".format(to_be_linked_version_id, original_version_id[0]),
+                         "debug")
+
+                # TODO: refactor to support bulk updates for performance concerns
+                if self.db is not None:
+
+                    # this is a live update session
+                    self.db.modulestore.structures.update(
+                        {'_id': {'$in': to_be_linked_version_id}},
+                        {'$set': {"previous_version": original_version_id[0]}})
+
+                else:
+
+                    # this is working against static dataset
+                    structures[index_position][u'previous_version'] = original_version_id[0]
+
+            else:
+                self.log("Nothing to link for structure: {0}".format(structure_doc['_id']), "debug")
+
+            # advance the index position
+            index_position += 1
+
+        return structures
+
+    def find_previous_version(self, lookup_key, lookup_value, structures_list):
+
+        """
+        This function searches all structure documents for the one specified
+        """
+
+        # it is more efficient to use a structures list
+        # instead of separate db calls (which may be necessary for supporting
+        # pruning individual active versions)
+        for structure_doc in structures_list:
+
+            if structure_doc[lookup_key] == lookup_value:
+                return structure_doc
+
+    def build_activeversion_tree(self, active_version, structures):
+
+        """
+        Build a tree representing the active_version and its tree of ancestors
+        from structures
+        """
+
+        # link the active version to its base version in structures
+        structure_doc = self.find_previous_version('_id', active_version, structures)
+
+        # map the tree for the identified structure
+        version_tree = []
+
+        # recursively identify the ancestors
+        if structure_doc is not None:
+
+            # build the tree
+            version_tree.append(str(structure_doc['_id']))
+
+            while structure_doc[u'previous_version'] is not None:
+
+                # search for the parent structure doc
+                structure_doc = self.find_previous_version('_id', structure_doc[u'previous_version'], structures)
+
+                # build the tree - recursively
+                if structure_doc is None:
+                    # end of the tree (original version)
+                    break
+
+                version_tree.append(str(structure_doc['_id']))
+
+        return version_tree
+
+    def get_structures_to_delete(self, active_versions, structures=None, version_retention=2, relink_structures=False):
+
+        """
+        Generate a list of structures that meet the conditions for pruning and associated visualization
+        """
+
+        # initialize key variables
+        version_trees = []
+        versions_to_retain = []
+        versions_to_remove = []
+        counter = 0
+
+        # iterate the active versions and build the associated version tree
+        for active_version in active_versions:
+
+            counter += 1
+
+            for target_key in self.target_active_versions_keys:
+
+                if target_key in active_version['versions']:
+
+                    # print(active_version)
+                    version_tree = self.build_activeversion_tree(active_version['versions'][target_key], structures)
+
+                    # only add the tree if it has 1+ element
+                    tree_length = len(version_tree)
+                    if tree_length > 0:
+
+                        status_message = "Processing Active Version {0} | {3}: {1} version with a {2}-version tree"
+
+                        self.log(status_message.format(
+                            counter,
+                            target_key,
+                            len(version_tree),
+                            str(active_version['_id'])))
+
+                        # if the tree exceeds the minimum number of elements,
+                        # identify tree elements that should be removed
+                        if tree_length > version_retention:
+
+                            # track the required version: first & last
+                            versions_to_retain.extend(version_tree[:2])
+
+                            # if relinking is not required, it is ok to remove the original version
+                            if not relink_structures:
+                                versions_to_retain.append(version_tree[-1])
+
+                            # This will extract the mid range of 1 to n+1 version id's from the version_tree
+                            versions_to_remove.extend(version_tree[version_retention - 1: len(version_tree) - 1])
+
+                            # tree mapping is complete, add to forest/list of trees
+                        # only useful for dry runs and graphing purposes
+                        version_trees.append(version_tree)
+
+        # All trees have been processed.
+        # We now have a final list of structures to retain & remove
+
+        # remove duplicates from the versions_to_retain
+        versions_to_retain = list(set(versions_to_retain))
+
+        # remove structures on the versions_to_remove list that are on the versions_to_retain list
+        # this supports course re-runs and related links
+        versions_to_remove = list(set(versions_to_remove) - set(versions_to_retain))
+
+        # return the list of items to remove
+        return {'versions_to_remove': versions_to_remove, 'version_trees': version_trees}
+
+    def get_database(self, connection, database_name):
+
+        """
+        Establish a connection to the database
+        """
+
+        if connection is None:
+            client = MongoClient()
+        else:
+            client = MongoClient(connection)
+
+        return client[database_name]

--- a/tubular/scripts/prune_modulestore.py
+++ b/tubular/scripts/prune_modulestore.py
@@ -86,7 +86,6 @@ def prune_modulestore(
     module_store = modulestore.ModuleStore(logger=LOG)
     structure_prune_data = None
 
-    # we are using live data
     # establish database connection
     LOG.info("Establishing database connection")
     module_store.initialize_database_connection(

--- a/tubular/scripts/prune_modulestore.py
+++ b/tubular/scripts/prune_modulestore.py
@@ -1,0 +1,559 @@
+#! /usr/bin/env python3
+
+"""
+[WIP]
+
+Command-line script used to clean up (trim) the modulestore structure. By virtue of its nature, the module store
+versions updates and over a period of time, these updates account for a significant growth in the size of the
+mongo database.
+
+This script prunes the modulestore structures using the parameters specified.
+
+The final product will support:
+    1. dry-run:
+    2. prune targeted course/active version
+    3. prune all active versions
+    4. support tests via static data
+    5. visualize targeted course trees
+
+Options 2 & 3 support removing all structures or keeping a number of older structures (in support of
+user-specified retention policy)
+
+See more details regarding module store at
+http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/modulestores/split-mongo.html
+
+See additional details regarding the growth problem with the modulestore at
+https://openedx.atlassian.net/browse/PLAT-697
+
+"""
+
+from __future__ import absolute_import
+
+import json
+import logging
+import os
+import sys
+import click
+import click_log
+from bson.objectid import ObjectId
+from pymongo import MongoClient
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+LOG = logging.getLogger(__name__)
+
+# the dictionary keys to track for active versions
+TARGET_ACTIVE_VERSIONS_KEYS = [u'library', u'draft-branch', u'published-branch']
+
+
+# parameter handling
+@click.command()
+@click.option(
+    u'--connection',
+    default=None,
+    help=u'Connection string to the target mongo database. This defaults to localhost without password.'
+)
+@click.option(
+    u'--version-retention',
+    default=2,
+    help=u'Number of versions to retain for a course/library'
+)
+@click.option(
+    u'--relink-structures',
+    default=False,
+    help=u'boolean indicator of whether or not to relink the structures to the original version after pruning'
+)
+@click.option(
+    u'--active-version-filter',
+    default=None,
+    help=u'comma-separated list of objectIds to target for pruning'
+)
+@click.option(
+    u'--database-name',
+    default=u'edxapp',
+    help=u'name of the edx database to prune'
+)
+@click.option(
+    u'--test-data-file',
+    default=None,
+    help=u'file path containing a json representation of test data to use for pruning validation'
+)
+@click.option(
+    u'--output-file',
+    default=u'pruned_dataset.json',
+    help=u'output file of the prune structures for test purposes'
+)
+@click_log.simple_verbosity_option(default=u'DEBUG')
+@click_log.init()
+def prune_modulestore(
+        connection,
+        version_retention,
+        relink_structures,
+        active_version_filter,
+        database_name,
+        test_data_file,
+        output_file):
+
+    """
+    Main script entry point for pruning the edxapp modulestore structures
+    """
+
+    # initialize the key variables
+    db_client = None
+    structure_prune_data = None
+    testmode_data = None
+    operation_status = 0
+
+    # ensure that version_rention 2+
+    if version_retention < 2:
+        raise ValueError("Version rention must be at at least 2: origin and active version")
+
+    # Support loading sample dataset from file system for test purposes
+    if test_data_file is not None:
+
+        LOG.debug("Test Mode Detected: loading datasets from '{0}'".format(test_data_file))
+
+        # load the test data
+        testmode_data = load_test_dataset(test_data_file)
+
+        # we are using test data
+        active_versions = testmode_data[u'active_versions']
+        structures = testmode_data[u'structures']
+
+    else:
+        # we are using live data
+        # establish database connection
+        LOG.debug("Establishing database connection")
+        db_client = get_database(connection, database_name)
+
+        # get the data: active versions (courses/library) and accompanying structures
+        # get a dictionary listing all active versions
+        active_versions = get_active_versions(db_client, active_version_filter)
+        LOG.debug("{0} active versions identified.".format(len(active_versions)))
+
+        # get the accompanying structures
+        filter_enabled = (active_version_filter is not None and len(active_versions) > 0)
+        structures = get_structures(db_client, filter_enabled, active_versions)
+        LOG.debug("{0} associated structure docs identified".format(len(structures)))
+
+    # identify structures that should be deleted
+    structure_prune_data = get_structures_to_delete(active_versions,
+                                                    structures,
+                                                    version_retention,
+                                                    relink_structures)
+
+    # prune structures
+    structure_prune_candidates = structure_prune_data[u'versions_to_remove']
+    LOG.debug("{0} structures identified for removal".format(len(structure_prune_candidates)))
+
+    if test_data_file is not None:
+
+        # we are pruning the static data instead of the database
+        pruned_dataset = prune_structures_static_data(testmode_data, structure_prune_candidates)
+
+        if relink_structures:
+            pruned_dataset[u'structures'] = relink(None, pruned_dataset[u'structures'])
+
+        # save the output
+        save_data_file(pruned_dataset, output_file)
+
+        operation_status = 1
+
+    else:
+
+        # we are pruning the live data
+        prune_structures(db_client, structure_prune_candidates)
+
+        if relink_structures:
+            relink(db_client, structures)
+
+        operation_status = 1
+
+    # An exit code of 0 means success and non-zero means failure.
+    return operation_status
+
+
+###################################
+# Support functions
+###################################
+
+def save_data_file(data, output_file):
+
+    """
+    Save the specified data file to disk
+    """
+
+    LOG.debug("Saving the purged dataset to {0}".format(output_file))
+
+    # write the updated dataset
+    with open(output_file, 'w') as outfile:
+        json.dump(data, outfile)
+
+
+def prune_structures_static_data(original_dataset, structures_to_remove):
+
+    """
+    Prune the static test data and return the results
+    """
+
+    pruned_static_data = []
+
+    for structure_doc in original_dataset[u'structures']:
+
+        if structure_doc[u'_id'] not in structures_to_remove:
+            pruned_static_data.append(structure_doc)
+
+    original_dataset[u'structures'] = pruned_static_data
+
+    return original_dataset
+
+
+def load_test_dataset(dataset_file):
+
+    """
+    Load the json dataset from the file specified
+    """
+
+    # check if the specified file exists
+    file_exists = os.path.isfile(dataset_file)
+
+    assert isinstance(file_exists, object)
+    if not file_exists:
+        raise IOError("The specified file doesn't exist: {0}".format(dataset_file))
+
+    # load the file
+    with open(dataset_file) as dataset:
+        data = json.load(dataset)
+
+    return data
+
+
+def get_query_filter(doc_filter):
+
+    """
+    Generate a document filter for bulk querying
+    """
+
+    # establish the query filter  (respecting cases where no value is specified)
+    query_filter = None
+
+    if len(doc_filter['$in']) > 0:
+        query_filter = {"_id": doc_filter}
+
+    return query_filter
+
+
+def get_active_version_filter(active_version_id_list):
+
+    """
+    Generate document filter for bulk querying the active version collection
+    """
+
+    av_filter = {'$in': []}
+
+    for active_version_id in active_version_id_list.split(","):
+        av_filter['$in'].append(ObjectId(active_version_id.strip()))
+
+    # establish the query filter  (respecting cases where no value is specified)
+    return get_query_filter(av_filter)
+
+
+def get_structures_filter(active_version_list):
+
+    """
+    Generate document filter for bulk querying the structures collection
+    """
+
+    structure_filter = {'$in': []}
+
+    for active_version in active_version_list:
+
+        for target_key in TARGET_ACTIVE_VERSIONS_KEYS:
+            if target_key in active_version['versions']:
+                structure_filter['$in'].append(ObjectId(active_version['versions'][target_key]))
+
+    # establish the query filter  (respecting cases where no value is specified)
+    return get_query_filter(structure_filter)
+
+
+def get_active_versions(db, active_version_list=None):
+
+    """
+    Get all documents from the active_versions collection
+    """
+
+    # establish the active version filter (if required)
+    active_version_filter = None
+
+    if active_version_list is not None:
+        active_version_filter = get_active_version_filter(active_version_list)
+
+    fields = {
+        "versions.draft-branch": 1,
+        "versions.published-branch": 1,
+        "versions.library": 1,
+    }
+
+    # initialize our active versions dictionary
+    active_versions = []
+
+    # TODO: apply filters here in support of a user limiting the pruning operation to 1+ course/active versions
+    if active_version_filter is None:
+        resultset = db.modulestore.active_versions.find({}, fields)
+    else:
+        resultset = db.modulestore.active_versions.find(active_version_filter, fields)
+
+    for active_version_doc in resultset:
+
+        # collect all interesting docs: library & [draft|published]-branch active versions
+        avdocs_versions = active_version_doc['versions']
+
+        if u'library' in avdocs_versions \
+                or u'draft-branch' in avdocs_versions \
+                or u'published-branch' in avdocs_versions:
+            active_versions.append(active_version_doc)
+
+    # return the active versions
+    return active_versions
+
+
+def get_structures(db, filter_enabled, active_versions_list):
+
+    """
+    Get all documents from the structures collection
+    """
+
+    # use filters (if required)
+    structure_filter = None
+    if filter_enabled:
+        structure_filter = get_structures_filter(active_versions_list)
+
+    fields = {
+        "_id": 1,
+        "previous_version": 1,
+        "original_version": 1
+    }
+
+    structures_list = []
+
+    # TODO: apply filters to support limiting the pruning operation to 1 or more courses / active versions
+    if structure_filter is None:
+        resultset = db.modulestore.structures.find({}, fields)
+    else:
+        resultset = db.modulestore.structures.find(structure_filter, fields)
+
+    for structure_doc in resultset:
+
+        # Get a list of all structures (or those relevant to the active versions via specified filter)
+        # this will give the list of Dictionary's with _id and previous_version
+        structures_list.append(structure_doc)
+
+    return structures_list
+
+
+def prune_structures(db, structures_to_remove):
+
+    """
+    Prune the specified documents from the structures collection
+    """
+
+    # TODO: (performance): chunk up the removals to minimize possible production impact
+    if len(structures_to_remove) == 0:
+        return
+
+    structures_removal_filter = {'$in': []}
+
+    for structure_objectid_str in structures_to_remove:
+        structures_removal_filter['$in'].append(ObjectId(structure_objectid_str))
+
+    return db.modulestore.structures.remove({'_id': structures_removal_filter})
+
+
+# TODO: get this fully operational. Test against static data is ready.
+def relink(db, structures):
+
+    """
+    There are ongoing discussions about the need to support relinking modulestore structures
+    to their original version.
+
+    Keeping this as a place holder.
+
+    """
+
+    LOG.debug("Relinking structure to original version")
+
+    index_position = 0
+    available_ids = []
+
+    # build a list of all available ids
+    available_ids.extend([structure_doc['_id'] for structure_doc in structures])
+
+    # iterate structures and relink to original
+    for structure_doc in structures:
+
+        if structure_doc["previous_version"] is not None and structure_doc["previous_version"] not in available_ids:
+
+            LOG.debug("{0} was not found in {1}".format(structure_doc["previous_version"], available_ids))
+
+            to_be_linked_version_id = []
+            original_version_id = []
+
+            to_be_linked_version_id.append(structure_doc['_id'])
+            original_version_id.append(structure_doc['original_version'])
+
+            LOG.debug("{0} version is being linked to {1}".format(to_be_linked_version_id, original_version_id[0]))
+
+            # TODO: refactor to support bulk updates for performance concerns
+            if db is not None:
+
+                # this is a live update session
+                db.modulestore.structures.update(
+                    {'_id': {'$in': to_be_linked_version_id}},
+                    {'$set': {"previous_version": original_version_id[0]}})
+
+            else:
+
+                # this is working against static dataset
+                structures[index_position][u'previous_version'] = original_version_id[0]
+
+        else:
+            LOG.debug("Nothing to link for structure: {0}".format(structure_doc['_id']))
+
+        # advance the index position
+        index_position += 1
+
+    return structures
+
+
+def find_previous_version(lookup_key, lookup_value, structures_list):
+
+    """
+    This function searches all structure documents for the one specified
+    """
+
+    # it is more efficient to use a structures list
+    # instead of separate db calls (which may be necessary for supporting
+    # pruning individual active versions)
+    for structure_doc in structures_list:
+
+        if structure_doc[lookup_key] == lookup_value:
+            return structure_doc
+
+
+def build_activeversion_tree(active_version, structures):
+
+    """
+    Build a tree representing the active_version and its tree of ancestors
+    from structures
+    """
+
+    # link the active version to its base version in structures
+    structure_doc = find_previous_version('_id', active_version, structures)
+
+    # map the tree for the identified structure
+    version_tree = []
+
+    # recursively identify the ancestors
+    if structure_doc is not None:
+
+        # build the tree
+        version_tree.append(str(structure_doc['_id']))
+
+        while structure_doc[u'previous_version'] is not None:
+
+            # search for the parent structure doc
+            structure_doc = find_previous_version('_id', structure_doc[u'previous_version'], structures)
+
+            # build the tree - recursively
+            if structure_doc is None:
+                # end of the tree (original version)
+                break
+
+            version_tree.append(str(structure_doc['_id']))
+
+    return version_tree
+
+
+def get_structures_to_delete(active_versions, structures=None, version_retention=2, relink_structures=False):
+
+    """
+    Generate a list of structures that meet the conditions for pruning and associated visualization
+    """
+
+    # initialize key variables
+    version_trees = []
+    versions_to_retain = []
+    versions_to_remove = []
+    counter = 0
+
+    # iterate the active versions and build the associated version tree
+    for active_version in active_versions:
+
+        counter += 1
+
+        for target_key in TARGET_ACTIVE_VERSIONS_KEYS:
+
+            if target_key in active_version['versions']:
+
+                # print(active_version)
+                version_tree = build_activeversion_tree(active_version['versions'][target_key], structures)
+
+                # only add the tree if it has 1+ element
+                tree_length = len(version_tree)
+                if tree_length > 0:
+
+                    status_message = "Processing Active Version {0} | {3}: {1} version with a {2}-version tree"
+
+                    LOG.debug(status_message.format(
+                        counter,
+                        target_key,
+                        len(version_tree),
+                        str(active_version['_id'])))
+
+                    # if the tree exceeds the minimum number of elements,
+                    # identify tree elements that should be removed
+                    if tree_length > version_retention:
+
+                        # track the required version: first & last
+                        versions_to_retain.extend(version_tree[:2])
+
+                        # if relinking is not required, it is ok to remove the original version
+                        if not relink_structures:
+                            versions_to_retain.append(version_tree[-1])
+
+                        # This will extract the mid range of 1 to n+1 version id's from the version_tree
+                        versions_to_remove.extend(version_tree[version_retention - 1: len(version_tree) - 1])
+
+                        # tree mapping is complete, add to forest/list of trees
+                    # only useful for dry runs and graphing purposes
+                    version_trees.append(version_tree)
+
+    # All trees have been processed.
+    # We now have a final list of structures to retain & remove
+
+    # remove duplicates from the versions_to_retain
+    versions_to_retain = list(set(versions_to_retain))
+
+    # remove structures on the versions_to_remove list that are on the versions_to_retain list
+    # this supports course re-runs and related links
+    versions_to_remove = list(set(versions_to_remove) - set(versions_to_retain))
+
+    # return the list of items to remove
+    return {'versions_to_remove': versions_to_remove, 'version_trees': version_trees}
+
+
+def get_database(connection, database_name):
+
+    """
+    Establish a connection to the database
+    """
+
+    if connection is None:
+        client = MongoClient()
+    else:
+        client = MongoClient(connection)
+
+    return client[database_name]
+
+
+if __name__ == '__main__':
+    prune_modulestore()  # pylint: disable=no-value-for-parameter

--- a/tubular/scripts/prune_modulestore.py
+++ b/tubular/scripts/prune_modulestore.py
@@ -28,21 +28,20 @@ https://openedx.atlassian.net/browse/PLAT-697
 """
 
 from __future__ import absolute_import
+from os import path
 
-import json
 import logging
-import os
 import sys
 import click
 import click_log
-from bson.objectid import ObjectId
-from pymongo import MongoClient
+
+# Add top-level module path to sys.path before importing tubular code.
+sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+
+from tubular import modulestore  # pylint: disable=wrong-import-position
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 LOG = logging.getLogger(__name__)
-
-# the dictionary keys to track for active versions
-TARGET_ACTIVE_VERSIONS_KEYS = [u'library', u'draft-branch', u'published-branch']
 
 
 # parameter handling
@@ -59,7 +58,7 @@ TARGET_ACTIVE_VERSIONS_KEYS = [u'library', u'draft-branch', u'published-branch']
 )
 @click.option(
     u'--relink-structures',
-    default=False,
+    default=True,
     help=u'boolean indicator of whether or not to relink the structures to the original version after pruning'
 )
 @click.option(
@@ -70,489 +69,61 @@ TARGET_ACTIVE_VERSIONS_KEYS = [u'library', u'draft-branch', u'published-branch']
 @click.option(
     u'--database-name',
     default=u'edxapp',
-    help=u'name of the edx database to prune'
+    help=u'name of the edx mongo database containing the course structures to prune'
 )
-@click.option(
-    u'--test-data-file',
-    default=None,
-    help=u'file path containing a json representation of test data to use for pruning validation'
-)
-@click.option(
-    u'--output-file',
-    default=u'pruned_dataset.json',
-    help=u'output file of the prune structures for test purposes'
-)
-@click_log.simple_verbosity_option(default=u'DEBUG')
+@click_log.simple_verbosity_option(default=u'INFO')
 @click_log.init()
 def prune_modulestore(
         connection,
         version_retention,
         relink_structures,
         active_version_filter,
-        database_name,
-        test_data_file,
-        output_file):
+        database_name):
 
     """
     Main script entry point for pruning the edxapp modulestore structures
     """
 
     # initialize the key variables
-    db_client = None
+    module_store = modulestore.ModuleStore(logger=LOG)
     structure_prune_data = None
-    testmode_data = None
-    operation_status = 0
 
-    # ensure that version_rention 2+
+    # ensure that version_retention is 2+
     if version_retention < 2:
-        raise ValueError("Version rention must be at at least 2: origin and active version")
+        raise ValueError("Version retention must be at at least 2: origin and active version")
 
-    # Support loading sample dataset from file system for test purposes
-    if test_data_file is not None:
+    # we are using live data
+    # establish database connection
+    LOG.info("Establishing database connection")
+    module_store.initialize_database_connection(
+        mongo_database_connection=connection,
+        mongo_database_name=database_name)
 
-        LOG.debug("Test Mode Detected: loading datasets from '{0}'".format(test_data_file))
+    # get the data: active versions (courses/library) and accompanying structures
+    active_versions = module_store.get_active_versions(active_version_filter)
+    LOG.info("{0} active versions identified.".format(len(active_versions)))
 
-        # load the test data
-        testmode_data = load_test_dataset(test_data_file)
-
-        # we are using test data
-        active_versions = testmode_data[u'active_versions']
-        structures = testmode_data[u'structures']
-
-    else:
-        # we are using live data
-        # establish database connection
-        LOG.debug("Establishing database connection")
-        db_client = get_database(connection, database_name)
-
-        # get the data: active versions (courses/library) and accompanying structures
-        # get a dictionary listing all active versions
-        active_versions = get_active_versions(db_client, active_version_filter)
-        LOG.debug("{0} active versions identified.".format(len(active_versions)))
-
-        # get the accompanying structures
-        filter_enabled = (active_version_filter is not None and len(active_versions) > 0)
-        structures = get_structures(db_client, filter_enabled, active_versions)
-        LOG.debug("{0} associated structure docs identified".format(len(structures)))
+    # get the accompanying structures
+    filter_enabled = (active_version_filter is not None and len(active_versions) > 0)
+    structures = module_store.get_structures(filter_enabled, active_versions)
+    LOG.info("{0} associated structure docs identified".format(len(structures)))
 
     # identify structures that should be deleted
-    structure_prune_data = get_structures_to_delete(active_versions,
-                                                    structures,
-                                                    version_retention,
-                                                    relink_structures)
+    structure_prune_data = module_store.get_structures_to_delete(
+        active_versions,
+        structures,
+        version_retention,
+        relink_structures)
 
     # prune structures
     structure_prune_candidates = structure_prune_data[u'versions_to_remove']
-    LOG.debug("{0} structures identified for removal".format(len(structure_prune_candidates)))
+    LOG.info("{0} structures identified for removal".format(len(structure_prune_candidates)))
 
-    if test_data_file is not None:
+    # we are pruning the live data
+    module_store.prune_structures(structure_prune_candidates)
 
-        # we are pruning the static data instead of the database
-        pruned_dataset = prune_structures_static_data(testmode_data, structure_prune_candidates)
-
-        if relink_structures:
-            pruned_dataset[u'structures'] = relink(None, pruned_dataset[u'structures'])
-
-        # save the output
-        save_data_file(pruned_dataset, output_file)
-
-        operation_status = 1
-
-    else:
-
-        # we are pruning the live data
-        prune_structures(db_client, structure_prune_candidates)
-
-        if relink_structures:
-            relink(db_client, structures)
-
-        operation_status = 1
-
-    # An exit code of 0 means success and non-zero means failure.
-    return operation_status
-
-
-###################################
-# Support functions
-###################################
-
-def save_data_file(data, output_file):
-
-    """
-    Save the specified data file to disk
-    """
-
-    LOG.debug("Saving the purged dataset to {0}".format(output_file))
-
-    # write the updated dataset
-    with open(output_file, 'w') as outfile:
-        json.dump(data, outfile)
-
-
-def prune_structures_static_data(original_dataset, structures_to_remove):
-
-    """
-    Prune the static test data and return the results
-    """
-
-    pruned_static_data = []
-
-    for structure_doc in original_dataset[u'structures']:
-
-        if structure_doc[u'_id'] not in structures_to_remove:
-            pruned_static_data.append(structure_doc)
-
-    original_dataset[u'structures'] = pruned_static_data
-
-    return original_dataset
-
-
-def load_test_dataset(dataset_file):
-
-    """
-    Load the json dataset from the file specified
-    """
-
-    # check if the specified file exists
-    file_exists = os.path.isfile(dataset_file)
-
-    assert isinstance(file_exists, object)
-    if not file_exists:
-        raise IOError("The specified file doesn't exist: {0}".format(dataset_file))
-
-    # load the file
-    with open(dataset_file) as dataset:
-        data = json.load(dataset)
-
-    return data
-
-
-def get_query_filter(doc_filter):
-
-    """
-    Generate a document filter for bulk querying
-    """
-
-    # establish the query filter  (respecting cases where no value is specified)
-    query_filter = None
-
-    if len(doc_filter['$in']) > 0:
-        query_filter = {"_id": doc_filter}
-
-    return query_filter
-
-
-def get_active_version_filter(active_version_id_list):
-
-    """
-    Generate document filter for bulk querying the active version collection
-    """
-
-    av_filter = {'$in': []}
-
-    for active_version_id in active_version_id_list.split(","):
-        av_filter['$in'].append(ObjectId(active_version_id.strip()))
-
-    # establish the query filter  (respecting cases where no value is specified)
-    return get_query_filter(av_filter)
-
-
-def get_structures_filter(active_version_list):
-
-    """
-    Generate document filter for bulk querying the structures collection
-    """
-
-    structure_filter = {'$in': []}
-
-    for active_version in active_version_list:
-
-        for target_key in TARGET_ACTIVE_VERSIONS_KEYS:
-            if target_key in active_version['versions']:
-                structure_filter['$in'].append(ObjectId(active_version['versions'][target_key]))
-
-    # establish the query filter  (respecting cases where no value is specified)
-    return get_query_filter(structure_filter)
-
-
-def get_active_versions(db, active_version_list=None):
-
-    """
-    Get all documents from the active_versions collection
-    """
-
-    # establish the active version filter (if required)
-    active_version_filter = None
-
-    if active_version_list is not None:
-        active_version_filter = get_active_version_filter(active_version_list)
-
-    fields = {
-        "versions.draft-branch": 1,
-        "versions.published-branch": 1,
-        "versions.library": 1,
-    }
-
-    # initialize our active versions dictionary
-    active_versions = []
-
-    # TODO: apply filters here in support of a user limiting the pruning operation to 1+ course/active versions
-    if active_version_filter is None:
-        resultset = db.modulestore.active_versions.find({}, fields)
-    else:
-        resultset = db.modulestore.active_versions.find(active_version_filter, fields)
-
-    for active_version_doc in resultset:
-
-        # collect all interesting docs: library & [draft|published]-branch active versions
-        avdocs_versions = active_version_doc['versions']
-
-        if u'library' in avdocs_versions \
-                or u'draft-branch' in avdocs_versions \
-                or u'published-branch' in avdocs_versions:
-            active_versions.append(active_version_doc)
-
-    # return the active versions
-    return active_versions
-
-
-def get_structures(db, filter_enabled, active_versions_list):
-
-    """
-    Get all documents from the structures collection
-    """
-
-    # use filters (if required)
-    structure_filter = None
-    if filter_enabled:
-        structure_filter = get_structures_filter(active_versions_list)
-
-    fields = {
-        "_id": 1,
-        "previous_version": 1,
-        "original_version": 1
-    }
-
-    structures_list = []
-
-    # TODO: apply filters to support limiting the pruning operation to 1 or more courses / active versions
-    if structure_filter is None:
-        resultset = db.modulestore.structures.find({}, fields)
-    else:
-        resultset = db.modulestore.structures.find(structure_filter, fields)
-
-    for structure_doc in resultset:
-
-        # Get a list of all structures (or those relevant to the active versions via specified filter)
-        # this will give the list of Dictionary's with _id and previous_version
-        structures_list.append(structure_doc)
-
-    return structures_list
-
-
-def prune_structures(db, structures_to_remove):
-
-    """
-    Prune the specified documents from the structures collection
-    """
-
-    # TODO: (performance): chunk up the removals to minimize possible production impact
-    if len(structures_to_remove) == 0:
-        return
-
-    structures_removal_filter = {'$in': []}
-
-    for structure_objectid_str in structures_to_remove:
-        structures_removal_filter['$in'].append(ObjectId(structure_objectid_str))
-
-    return db.modulestore.structures.remove({'_id': structures_removal_filter})
-
-
-# TODO: get this fully operational. Test against static data is ready.
-def relink(db, structures):
-
-    """
-    There are ongoing discussions about the need to support relinking modulestore structures
-    to their original version.
-
-    Keeping this as a place holder.
-
-    """
-
-    LOG.debug("Relinking structure to original version")
-
-    index_position = 0
-    available_ids = []
-
-    # build a list of all available ids
-    available_ids.extend([structure_doc['_id'] for structure_doc in structures])
-
-    # iterate structures and relink to original
-    for structure_doc in structures:
-
-        if structure_doc["previous_version"] is not None and structure_doc["previous_version"] not in available_ids:
-
-            LOG.debug("{0} was not found in {1}".format(structure_doc["previous_version"], available_ids))
-
-            to_be_linked_version_id = []
-            original_version_id = []
-
-            to_be_linked_version_id.append(structure_doc['_id'])
-            original_version_id.append(structure_doc['original_version'])
-
-            LOG.debug("{0} version is being linked to {1}".format(to_be_linked_version_id, original_version_id[0]))
-
-            # TODO: refactor to support bulk updates for performance concerns
-            if db is not None:
-
-                # this is a live update session
-                db.modulestore.structures.update(
-                    {'_id': {'$in': to_be_linked_version_id}},
-                    {'$set': {"previous_version": original_version_id[0]}})
-
-            else:
-
-                # this is working against static dataset
-                structures[index_position][u'previous_version'] = original_version_id[0]
-
-        else:
-            LOG.debug("Nothing to link for structure: {0}".format(structure_doc['_id']))
-
-        # advance the index position
-        index_position += 1
-
-    return structures
-
-
-def find_previous_version(lookup_key, lookup_value, structures_list):
-
-    """
-    This function searches all structure documents for the one specified
-    """
-
-    # it is more efficient to use a structures list
-    # instead of separate db calls (which may be necessary for supporting
-    # pruning individual active versions)
-    for structure_doc in structures_list:
-
-        if structure_doc[lookup_key] == lookup_value:
-            return structure_doc
-
-
-def build_activeversion_tree(active_version, structures):
-
-    """
-    Build a tree representing the active_version and its tree of ancestors
-    from structures
-    """
-
-    # link the active version to its base version in structures
-    structure_doc = find_previous_version('_id', active_version, structures)
-
-    # map the tree for the identified structure
-    version_tree = []
-
-    # recursively identify the ancestors
-    if structure_doc is not None:
-
-        # build the tree
-        version_tree.append(str(structure_doc['_id']))
-
-        while structure_doc[u'previous_version'] is not None:
-
-            # search for the parent structure doc
-            structure_doc = find_previous_version('_id', structure_doc[u'previous_version'], structures)
-
-            # build the tree - recursively
-            if structure_doc is None:
-                # end of the tree (original version)
-                break
-
-            version_tree.append(str(structure_doc['_id']))
-
-    return version_tree
-
-
-def get_structures_to_delete(active_versions, structures=None, version_retention=2, relink_structures=False):
-
-    """
-    Generate a list of structures that meet the conditions for pruning and associated visualization
-    """
-
-    # initialize key variables
-    version_trees = []
-    versions_to_retain = []
-    versions_to_remove = []
-    counter = 0
-
-    # iterate the active versions and build the associated version tree
-    for active_version in active_versions:
-
-        counter += 1
-
-        for target_key in TARGET_ACTIVE_VERSIONS_KEYS:
-
-            if target_key in active_version['versions']:
-
-                # print(active_version)
-                version_tree = build_activeversion_tree(active_version['versions'][target_key], structures)
-
-                # only add the tree if it has 1+ element
-                tree_length = len(version_tree)
-                if tree_length > 0:
-
-                    status_message = "Processing Active Version {0} | {3}: {1} version with a {2}-version tree"
-
-                    LOG.debug(status_message.format(
-                        counter,
-                        target_key,
-                        len(version_tree),
-                        str(active_version['_id'])))
-
-                    # if the tree exceeds the minimum number of elements,
-                    # identify tree elements that should be removed
-                    if tree_length > version_retention:
-
-                        # track the required version: first & last
-                        versions_to_retain.extend(version_tree[:2])
-
-                        # if relinking is not required, it is ok to remove the original version
-                        if not relink_structures:
-                            versions_to_retain.append(version_tree[-1])
-
-                        # This will extract the mid range of 1 to n+1 version id's from the version_tree
-                        versions_to_remove.extend(version_tree[version_retention - 1: len(version_tree) - 1])
-
-                        # tree mapping is complete, add to forest/list of trees
-                    # only useful for dry runs and graphing purposes
-                    version_trees.append(version_tree)
-
-    # All trees have been processed.
-    # We now have a final list of structures to retain & remove
-
-    # remove duplicates from the versions_to_retain
-    versions_to_retain = list(set(versions_to_retain))
-
-    # remove structures on the versions_to_remove list that are on the versions_to_retain list
-    # this supports course re-runs and related links
-    versions_to_remove = list(set(versions_to_remove) - set(versions_to_retain))
-
-    # return the list of items to remove
-    return {'versions_to_remove': versions_to_remove, 'version_trees': version_trees}
-
-
-def get_database(connection, database_name):
-
-    """
-    Establish a connection to the database
-    """
-
-    if connection is None:
-        client = MongoClient()
-    else:
-        client = MongoClient(connection)
-
-    return client[database_name]
+    if relink_structures:
+        module_store.relink(structures)
 
 
 if __name__ == '__main__':

--- a/tubular/tests/test_prune_modulestore.py
+++ b/tubular/tests/test_prune_modulestore.py
@@ -98,13 +98,7 @@ class TestModuleStorePruning(unittest.TestCase):
 
         """
 
-        found = False
-        for structure_doc in structures:
-            if structure_doc['_id'] == key:
-                found = True
-                break
-
-        return found
+        return any(structure_doc['_id'] == key for structure_doc in structures)
 
     def get_unique_structure_ids(self, structures):
 

--- a/tubular/tests/test_prune_modulestore.py
+++ b/tubular/tests/test_prune_modulestore.py
@@ -1,0 +1,57 @@
+"""
+Tests for pruning modulestore
+"""
+
+from __future__ import absolute_import
+
+import os
+import unittest
+
+
+class TestModuleStorePruning(unittest.TestCase):
+    u"""
+    Test basic modulestore pruning
+    """
+
+    # output file for post-prune data
+    output_file = u"output.json"
+
+    # input file: static dataset
+    input_file = u"test_prune_modulestore_data.json"
+
+    def remove_output_file(self):
+        """
+        Removes residual test output
+        """
+        # check if the specified file exists
+        file_exists = os.path.isfile(self.output_file)
+
+        assert isinstance(file_exists, object)
+        if file_exists:
+            # there is residual output
+            os.remove(self.output_file)
+
+    def setUp(self):
+        # make sure we remove any residual output file
+        # this is defensive
+
+        super(TestModuleStorePruning, self).setUp()
+
+        self.remove_output_file()
+
+    def tearDown(self):
+        # make sure we remove any residual output fileimport tubular.jenkins as jenkins
+        super(TestModuleStorePruning, self).tearDown()
+        self.remove_output_file()
+
+    def test_structures_prune(self):
+        """
+        Run the structure pruning operation
+        """
+
+        # stub
+        self.assertEqual(True, True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tubular/tests/test_prune_modulestore.py
+++ b/tubular/tests/test_prune_modulestore.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 import logging
 import os
 import sys
+import tempfile
 import unittest
 import tubular.modulestore as modulestore
 
@@ -15,12 +16,47 @@ class TestModuleStorePruning(unittest.TestCase):
 
     """
     Test basic modulestore pruning
+
+    This test class consumes a sample dataset and execute various tests
+    against the dataset. The basic pattern for testing against a custom
+    dataset is as follows:
+
+    1.  create your custom dataset and save it (reference structure of
+        test_prune_modulestore_data.json)
+    2.  add the new datafile to the test folder
+    3.  run the tests
+
+    How to generate the custom dataset
+    1. query the active_versions collection with the following
+       selection fields and any custom filter to limit the dataset:
+
+       fields = {
+            "versions.draft-branch": 1,
+            "versions.published-branch": 1,
+            "versions.library": 1,
+        }
+
+        The results can be saved as a list of dictionaries. This
+        forms the "active_versions" dictionary key in the sample dataset.
+
+    2. query the structures collection with the following selection
+       fields:
+
+       fields = {
+            "_id": 1,
+            "previous_version": 1,
+            "original_version": 1
+        }
+
+        Limiting the dataset is difficult and requires iterative queries
+        that can be costly when run against a large production database.
+        The results can be saved as a list of dictionaries. This forms the
+        "structures" dictionary key in the sample dataset. Make sure to remove
+        all dictionaries with duplicate _id values.
+
     """
 
-    # output file for post-prune data
-    output_file = os.path.join(os.path.dirname(__file__), "output.json")
-
-    # input file: static dataset
+    # input file: static data set
     input_file = os.path.join(os.path.dirname(__file__), "test_prune_modulestore_data.json")
 
     # module store reference
@@ -29,45 +65,37 @@ class TestModuleStorePruning(unittest.TestCase):
     # test data
     test_data = None
 
-    def remove_output_file(self):
-
-        """
-        Removes residual test output
-        """
-        # check if the specified file exists
-        file_exists = os.path.isfile(self.output_file)
-
-        assert isinstance(file_exists, object)
-        if file_exists:
-            # there is residual output
-            os.remove(self.output_file)
-
     @classmethod
     def setUpClass(cls):
         super(TestModuleStorePruning, cls).setUpClass()
 
-        # intialize the logger
+        # initialize the logger
         logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
         logger = logging.getLogger(__name__)
 
         # initialize the module store libraries
         cls.module_store = modulestore.ModuleStore(logger)
 
-        # load the test data
-        # testmode_data = data
-        # we are using test data
-        cls.test_data = cls.module_store.load_test_dataset(cls.input_file)
-
     def setUp(self):
-        # make sure we remove any residual output file
-        # this is defensive
-
         super(TestModuleStorePruning, self).setUp()
-        self.remove_output_file()
+
+        # load the test data
+        self.module_store.log("Loading test data")
+        self.test_data = self.module_store.load_test_dataset(self.input_file)
 
     def find_structure(self, structures, key):
+
         """
         Support function for locating a structure from a list of structures
+
+        :param structures: list of structure dictionaries:
+            ** '_id': an ObjectId (guid),
+            ** 'original_version': the original structure id in the previous_version relation
+            ** 'previous_version': the structure id from which this one was derived. For published courses, this
+                                    points to the previously published version of the structure not the draft
+                                    published to this.
+        :param key: name of a dictionary key in structures to use for lookup
+
         """
 
         found = False
@@ -78,52 +106,138 @@ class TestModuleStorePruning(unittest.TestCase):
 
         return found
 
-    def test_default_structures_prune(self):
+    def get_unique_structure_ids(self, structures):
+
+        """
+        Generate a unique set of structure ids from the provided list of structures
+
+        :param structures: list of structure dictionaries:
+            ** '_id': an ObjectId (guid),
+            ** 'original_version': the original structure id in the previous_version relation
+            ** 'previous_version': the structure id from which this one was derived. For published courses, this
+                                    points to the previously published version of the structure not the draft
+                                    published to this.
+
+        """
+
+        unique_structure_ids = {structure_doc['_id'] for structure_doc in structures}
+        return unique_structure_ids
+
+    def prune_structure(self,
+                        version_retention=2,
+                        removed_structure_ids=None,
+                        retained_structure_ids=None,
+                        output_file_path=None):
 
         """
         Run the structure pruning operation
+
+        :param version_retention: the number of structures to retain in a course/library ancestral list post pruning
+        :param removed_structure_ids: list of structure ids expected to be removed (used for correctness test)
+        :param retained_structure_ids: list of structure ids expected to be retained (used for correctness test)
+        :param output_file_path: file system path to save the pruned result set (used for visualization)
+
         """
 
         # quick test on the data
-        active_versions = self.test_data[u'active_versions']
-        structures = self.test_data[u'structures']
+        active_versions = self.test_data['active_versions']
+        structures = self.test_data['structures']
 
-        # identify structures that should be deleted
-        version_retention = 2
-        relink_structures = True
-
+        self.module_store.log("Using Retention=%s" % version_retention)
         structure_prune_data = self.module_store.get_structures_to_delete(
             active_versions,
             structures,
-            version_retention,
-            relink_structures)
+            version_retention)
 
         # we are pruning the static data instead of the database
-        pruned_dataset = self.module_store.prune_structures_static_data(
-            self.test_data,
+        pruned_structures = self.module_store.prune_structures_static_data(
+            self.test_data['structures'],
             structure_prune_data['versions_to_remove'])
 
-        if relink_structures:
-            pruned_dataset[u'structures'] = self.module_store.relink(pruned_dataset[u'structures'])
+        relinked_pruned_structures = self.module_store.relink(pruned_structures)
 
         # basic output test
-        # there should be no changes to the active versions
-        self.assertEqual(len(self.test_data[u'active_versions']), len(pruned_dataset[u'active_versions']))
+
+        # reassemble the dataset
+        pruned_dataset = {'active_versions': active_versions, 'structures': relinked_pruned_structures}
 
         # save the output
-        output_data_file = os.path.join(os.path.dirname(__file__), self.output_file)
-        self.module_store.save_data_file(pruned_dataset, output_data_file)
+        output_data_file_object = tempfile.NamedTemporaryFile(delete=True)
 
-        # test for output file
-        self.assertEqual(True, os.path.isfile(output_data_file))
+        try:
 
-        # after pruning, the remaining structures will be 15
-        self.assertEqual(9, len(pruned_dataset[u'structures']))
+            # exercise the file save
+            self.module_store.save_data_file(
+                data=pruned_dataset,
+                output_file_object=output_data_file_object)
 
-        # perform correctness tests: specific structures would have been pruned
-        self.assertEqual(False, self.find_structure(pruned_dataset[u'structures'], '58dd0fd4620de9c0c9793627'))
-        self.assertEqual(False, self.find_structure(pruned_dataset[u'structures'], '58dd0fd4620de9c0c9ea7e27'))
-        self.assertEqual(False, self.find_structure(pruned_dataset[u'structures'], '58cd0fd4620dedc0c9ea7e29'))
+            # optionally save the output if a path is specified
+            if output_file_path:
+                self.module_store.save_data_file(
+                    data=pruned_dataset,
+                    output_file=output_file_path)
+
+            # dynamically determine the count of structure after pruning
+            unique_structure_ids = self.get_unique_structure_ids(structures)
+            expected_pruned_versions_count = len(unique_structure_ids) - len(structure_prune_data['versions_to_remove'])
+
+            # validate the expected count of post-prune structures
+            self.assertEqual(expected_pruned_versions_count, len(relinked_pruned_structures))
+
+            # perform correctness tests: check structures that should be removed
+            if removed_structure_ids:
+                for structure_id in removed_structure_ids:
+                    self.module_store.log("Check: %s should be removed" % structure_id)
+                    self.assertEqual(False, self.find_structure(relinked_pruned_structures, structure_id))
+
+            # perform correctness tests: check structures that should be retained
+            if retained_structure_ids:
+                for structure_id in retained_structure_ids:
+                    self.module_store.log("Check: %s should be retained" % structure_id)
+                    self.assertEqual(True, self.find_structure(relinked_pruned_structures, structure_id))
+
+        finally:
+            # ensure removal of the temp file
+            output_data_file_object.close()
+
+    def test_structures_prune(self):
+
+        """
+        Test structure pruning with retention = 3
+        This means, the course/library ancestral tree will contain at most
+        4 members: the active version, its previous version and the original version
+        """
+
+        # the below filters are specific to the test data
+        # active, previous & original versions must be retained.
+        # The third structure in ancestry will be retained (retention=3)
+        retained_structures = ['595f47eae9ec2154eceba297', '58dd9d18620de9c0be7937c3', '583602b0e9ec21ec98727b80',
+                               '58dd0fd4620de9c0c9793627']
+
+        # fourth & fifth structures in ancestry must be removed (retention=2)
+        removed_structures = ['58cd0fd4620dedc0c9ea7e29', '58dd0fd4620de9c0c9ea7e27']
+
+        self.prune_structure(version_retention=4,
+                             retained_structure_ids=retained_structures,
+                             removed_structure_ids=removed_structures,
+                             output_file_path="/tmp/output.json")
+
+    def test_default_structures_prune(self):
+
+        """
+        Test structure pruning with retention = 2
+        This means, the course/library ancestral tree will contain at most
+        3 members: the active version, its previous version and the original version
+        """
+
+        # the below filters are specific to the test data
+        # active, previous & original versions must be retained
+        retained_structures = ['595f47eae9ec2154eceba297', '58dd9d18620de9c0be7937c3', '583602b0e9ec21ec98727b80']
+
+        # third, fourth & fifth structures in ancestry must be removed (retention=2)
+        removed_structures = ['58dd0fd4620de9c0c9793627', '58cd0fd4620dedc0c9ea7e29', '58dd0fd4620de9c0c9ea7e27']
+
+        self.prune_structure(retained_structure_ids=retained_structures, removed_structure_ids=removed_structures)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tubular/tests/test_prune_modulestore.py
+++ b/tubular/tests/test_prune_modulestore.py
@@ -4,22 +4,33 @@ Tests for pruning modulestore
 
 from __future__ import absolute_import
 
+import logging
 import os
+import sys
 import unittest
+import tubular.modulestore as modulestore
 
 
 class TestModuleStorePruning(unittest.TestCase):
-    u"""
+
+    """
     Test basic modulestore pruning
     """
 
     # output file for post-prune data
-    output_file = u"output.json"
+    output_file = os.path.join(os.path.dirname(__file__), "output.json")
 
     # input file: static dataset
-    input_file = u"test_prune_modulestore_data.json"
+    input_file = os.path.join(os.path.dirname(__file__), "test_prune_modulestore_data.json")
+
+    # module store reference
+    module_store = None
+
+    # test data
+    test_data = None
 
     def remove_output_file(self):
+
         """
         Removes residual test output
         """
@@ -31,27 +42,88 @@ class TestModuleStorePruning(unittest.TestCase):
             # there is residual output
             os.remove(self.output_file)
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestModuleStorePruning, cls).setUpClass()
+
+        # intialize the logger
+        logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+        logger = logging.getLogger(__name__)
+
+        # initialize the module store libraries
+        cls.module_store = modulestore.ModuleStore(logger)
+
+        # load the test data
+        # testmode_data = data
+        # we are using test data
+        cls.test_data = cls.module_store.load_test_dataset(cls.input_file)
+
     def setUp(self):
         # make sure we remove any residual output file
         # this is defensive
 
         super(TestModuleStorePruning, self).setUp()
-
         self.remove_output_file()
 
-    def tearDown(self):
-        # make sure we remove any residual output fileimport tubular.jenkins as jenkins
-        super(TestModuleStorePruning, self).tearDown()
-        self.remove_output_file()
+    def find_structure(self, structures, key):
+        """
+        Support function for locating a structure from a list of structures
+        """
 
-    def test_structures_prune(self):
+        found = False
+        for structure_doc in structures:
+            if structure_doc['_id'] == key:
+                found = True
+                break
+
+        return found
+
+    def test_default_structures_prune(self):
+
         """
         Run the structure pruning operation
         """
 
-        # stub
-        self.assertEqual(True, True)
+        # quick test on the data
+        active_versions = self.test_data[u'active_versions']
+        structures = self.test_data[u'structures']
 
+        # identify structures that should be deleted
+        version_retention = 2
+        relink_structures = True
+
+        structure_prune_data = self.module_store.get_structures_to_delete(
+            active_versions,
+            structures,
+            version_retention,
+            relink_structures)
+
+        # we are pruning the static data instead of the database
+        pruned_dataset = self.module_store.prune_structures_static_data(
+            self.test_data,
+            structure_prune_data['versions_to_remove'])
+
+        if relink_structures:
+            pruned_dataset[u'structures'] = self.module_store.relink(pruned_dataset[u'structures'])
+
+        # basic output test
+        # there should be no changes to the active versions
+        self.assertEqual(len(self.test_data[u'active_versions']), len(pruned_dataset[u'active_versions']))
+
+        # save the output
+        output_data_file = os.path.join(os.path.dirname(__file__), self.output_file)
+        self.module_store.save_data_file(pruned_dataset, output_data_file)
+
+        # test for output file
+        self.assertEqual(True, os.path.isfile(output_data_file))
+
+        # after pruning, the remaining structures will be 15
+        self.assertEqual(9, len(pruned_dataset[u'structures']))
+
+        # perform correctness tests: specific structures would have been pruned
+        self.assertEqual(False, self.find_structure(pruned_dataset[u'structures'], '58dd0fd4620de9c0c9793627'))
+        self.assertEqual(False, self.find_structure(pruned_dataset[u'structures'], '58dd0fd4620de9c0c9ea7e27'))
+        self.assertEqual(False, self.find_structure(pruned_dataset[u'structures'], '58cd0fd4620dedc0c9ea7e29'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tubular/tests/test_prune_modulestore_data.json
+++ b/tubular/tests/test_prune_modulestore_data.json
@@ -1,0 +1,94 @@
+{
+    "active_versions": [
+        {
+            "_id": "583602b0e9ec21ec98727b81",
+            "versions": {
+                "draft-branch": "595f47eae9ec2154eceba297",
+                "published-branch": "595f47eae9ec2154eceba295"
+            }
+        },
+        {
+            "_id": "5836042ae9ec21ec8d727b81",
+            "versions": {
+                "library": "5876bb3077238e18e7d9c33e"
+            }
+        }
+    ],
+    "structures": [
+        {
+            "_id": "595f47eae9ec2154eceba297",
+            "original_version": "583602b0e9ec21ec98727b80",
+            "previous_version": "58dd9d18620de9c0be7937c3"
+        },
+        {
+            "_id": "58dd9d18620de9c0be7937c3",
+            "previous_version": "58dd0fd4620de9c0c9793627",
+            "original_version": "583602b0e9ec21ec98727b80"
+        },
+        {
+            "_id": "58dd0fd4620de9c0c9793627",
+            "previous_version": "58dd0fd4620de9c0c9ea7e27",
+            "original_version": "583602b0e9ec21ec98727b80"
+        },
+        {
+            "_id": "58dd0fd4620de9c0c9ea7e27",
+            "previous_version": "58cd0fd4620dedc0c9ea7e29",
+            "original_version": "583602b0e9ec21ec98727b80"
+        },
+        {
+            "_id": "58cd0fd4620dedc0c9ea7e29",
+            "previous_version": "583602b0e9ec21ec98727b80",
+            "original_version": "583602b0e9ec21ec98727b80"
+        },
+        {
+            "_id": "583602b0e9ec21ec98727b80",
+            "previous_version": null,
+            "original_version": "583602b0e9ec21ec98727b80"
+        },
+        {
+            "_id": "583602b0e9ec21ec98727b82",
+            "previous_version": null,
+            "original_version": "583602b0e9ec21ec98727b82"
+        },
+        {
+            "_id": "595f47eae9ec2154eceba295",
+            "original_version": "583602b0e9ec21ec98727b82",
+            "previous_version": "58dd9d18620de9c0be7937c4"
+        },
+        {
+            "_id": "58dd9d18620de9c0be7937c4",
+            "previous_version": "58dd0fd4620de9c0c9793625",
+            "original_version": "583602b0e9ec21ec98727b82"
+        },
+        {
+            "_id": "58dd0fd4620de9c0c9793625",
+            "original_version": "583602b0e9ec21ec98727b82",
+            "previous_version": "583602b0e9ec21ec98727b82"
+        },
+        {
+            "_id": "5876bb3077238e18e7d9c33e",
+            "original_version": "5836042ae9ec21ec8d727b80",
+            "previous_version": "5876ba1077238e18d5d9c3e1"
+        },
+        {
+            "_id": "5876ba1077238e18d5d9c3e1",
+            "previous_version": "584b4f9b77238edd2c55ff1a",
+            "original_version": "5836042ae9ec21ec8d727b80"
+        },
+        {
+            "_id": "584b4f9b77238edd2c55ff1a",
+            "original_version": "5836042ae9ec21ec8d727b80",
+            "previous_version": "584b4f7677238edd2155ff51"
+        },
+        {
+            "_id": "584b4f7677238edd2155ff51",
+            "previous_version": "5836042ae9ec21ec8d727b80",
+            "original_version": "5836042ae9ec21ec8d727b80"
+        },
+        {
+            "_id": "5836042ae9ec21ec8d727b80",
+            "previous_version": null,
+            "original_version": "5836042ae9ec21ec8d727b80"
+        }
+    ]
+}

--- a/tubular/tests/test_prune_modulestore_data.json
+++ b/tubular/tests/test_prune_modulestore_data.json
@@ -12,6 +12,20 @@
             "versions": {
                 "library": "5876bb3077238e18e7d9c33e"
             }
+        },
+        {
+            "_id": "59975760ce3cb24d8ce50509",
+            "versions": {
+                "draft-branch": "5997577fce3cb24d88e5050c",
+                "published-branch": "59975784ce3cb24d88e5050d"
+            }
+        },
+        {
+            "_id": "59975998ce3cb22ddc351880",
+            "versions": {
+                "draft-branch": "599759c5ce3cb24d86e5050d",
+                "published-branch": "599759d1ce3cb24d86e5050f"
+            }
         }
     ],
     "structures": [
@@ -89,6 +103,116 @@
             "_id": "5836042ae9ec21ec8d727b80",
             "previous_version": null,
             "original_version": "5836042ae9ec21ec8d727b80"
+        },
+        {
+            "_id": "59975763ce3cb24d86e50508",
+            "original_version": "59975760ce3cb24d8ce50508",
+            "previous_version": "59975760ce3cb24d8ce50508"
+        },
+        {
+            "_id": "59975760ce3cb24d8ce5050a",
+            "previous_version": null,
+            "original_version": "59975760ce3cb24d8ce5050a"
+        },
+        {
+            "_id": "59975760ce3cb24d8ce50508",
+            "previous_version": null,
+            "original_version": "59975760ce3cb24d8ce50508"
+        },
+        {
+            "_id": "59975763ce3cb24d86e50509",
+            "original_version": "59975760ce3cb24d8ce5050a",
+            "previous_version": "59975760ce3cb24d8ce5050a"
+        },
+        {
+            "_id": "59975764ce3cb24d88e50508",
+            "previous_version": "59975763ce3cb24d86e50508",
+            "original_version": "59975760ce3cb24d8ce50508"
+        },
+        {
+            "_id": "59975764ce3cb24d88e50509",
+            "previous_version": "59975763ce3cb24d86e50509",
+            "original_version": "59975760ce3cb24d8ce5050a"
+        },
+        {
+            "_id": "59975766ce3cb24d86e5050b",
+            "original_version": "59975760ce3cb24d8ce50508",
+            "previous_version": "59975764ce3cb24d88e50508"
+        },
+        {
+            "_id": "59975769ce3cb24d8ce5050d",
+            "previous_version": "59975766ce3cb24d86e5050b",
+            "original_version": "59975760ce3cb24d8ce50508"
+        },
+        {
+            "_id": "59975769ce3cb24d8ce5050e",
+            "original_version": "59975760ce3cb24d8ce50508",
+            "previous_version": "59975769ce3cb24d8ce5050d"
+        },
+        {
+            "_id": "59975770ce3cb24d88e5050a",
+            "original_version": "59975760ce3cb24d8ce5050a",
+            "previous_version": "59975764ce3cb24d88e50509"
+        },
+        {
+            "_id": "59975779ce3cb24d88e5050b",
+            "previous_version": "59975769ce3cb24d8ce5050e",
+            "original_version": "59975760ce3cb24d8ce50508"
+        },
+        {
+            "_id": "5997577ece3cb24d8ce50510",
+            "original_version": "59975760ce3cb24d8ce50508",
+            "previous_version": "59975779ce3cb24d88e5050b"
+        },
+        {
+            "_id": "5997577fce3cb24d88e5050c",
+            "previous_version": "5997577ece3cb24d8ce50510",
+            "original_version": "59975760ce3cb24d8ce50508"
+        },
+        {
+            "_id": "59975784ce3cb24d88e5050d",
+            "previous_version": "59975770ce3cb24d88e5050a",
+            "original_version": "59975760ce3cb24d8ce5050a"
+        },
+        {
+            "_id": "59975998ce3cb22ddc35187e",
+            "original_version": "59975760ce3cb24d8ce50508",
+            "previous_version": "5997577fce3cb24d88e5050c"
+        },
+        {
+            "_id": "599759bcce3cb24d87e50507",
+            "original_version": "59975760ce3cb24d8ce5050a",
+            "previous_version": "59975784ce3cb24d88e5050d"
+        },
+        {
+            "_id": "599759c0ce3cb24d8ce50512",
+            "previous_version": "59975998ce3cb22ddc35187e",
+            "original_version": "59975760ce3cb24d8ce50508"
+        },
+        {
+            "_id": "599759c0ce3cb24d8ce50513",
+            "previous_version": "599759bcce3cb24d87e50507",
+            "original_version": "59975760ce3cb24d8ce5050a"
+        },
+        {
+            "_id": "599759c1ce3cb24d8ce50515",
+            "original_version": "59975760ce3cb24d8ce50508",
+            "previous_version": "599759c0ce3cb24d8ce50512"
+        },
+        {
+            "_id": "599759c5ce3cb24d86e5050d",
+            "previous_version": "599759c1ce3cb24d8ce50515",
+            "original_version": "59975760ce3cb24d8ce50508"
+        },
+        {
+            "_id": "599759c7ce3cb24d86e5050e",
+            "original_version": "59975760ce3cb24d8ce5050a",
+            "previous_version": "599759c0ce3cb24d8ce50513"
+        },
+        {
+            "_id": "599759d1ce3cb24d86e5050f",
+            "previous_version": "599759c7ce3cb24d86e5050e",
+            "original_version": "59975760ce3cb24d8ce5050a"
         }
     ]
 }


### PR DESCRIPTION
> ### This is work in progress

This PR introduces initial code for handling splitmongo pruning. 

**Core capabilities currently available**:
1. querying specified edxapp database active_versions and structures collections 
2. identifying all structures that can be removed
3. removing identified structures

All capabilities above are supported for both 
1. live (ie: actual database interaction) 
2. static (using test data)

**Although functional, do not run this against a live database.**

Additional capabilities that are in progress (or targeted):
1. addressing performance concerns about pulling all documents in active_versions and structures collections at once
2. enabling visualization of sample course/library structures before and after pruning

**Running against sample data**:
`python tubular/scripts/prune_modulestore.py --relink-structures True --test-data-file tubular/tests/test_prune_modulestore_data.json --output-file ~/pruned_output.json`

**Known Issues**:
1. ~~this script **doesn't** work against the **Ginkgo" release~~