### PR TITLE
Add delay and batch to structures.py make_plan.

### DIFF
--- a/tubular/scripts/structures.py
+++ b/tubular/scripts/structures.py
@@ -84,8 +84,25 @@ def cli(ctx, connection, database_name):
         "to 2. Put 0 here if you want to prune as much as possible."
     )
 )
+@click.option(
+    '--delay',
+    default=5000,
+    type=click.IntRange(0, None),
+    help=(
+        "Delay in milliseconds between queries to fetch structures from MongoDB "
+        " during plan creation. Tune to adjust load on the database."
+    )
+)
+@click.option(
+    '--batch-size',
+    default=10000,
+    type=click.IntRange(1, None),
+    help=(
+        "How many Structures do we fetch at a time?"
+    )
+)
 @click.pass_context
-def make_plan(ctx, plan_file, details, retain):
+def make_plan(ctx, plan_file, details, retain, delay, batch_size):
     """
     Create a Change Plan JSON file describing the operations needed to prune the
     database. This command is read-only and does not alter the database.
@@ -114,7 +131,7 @@ def make_plan(ctx, plan_file, details, retain):
     to have to scan every document in the collection. We saw a read rate of
     ~50K structures/minute while load testing.
     """
-    structures_graph = ctx.obj['BACKEND'].structures_graph()
+    structures_graph = ctx.obj['BACKEND'].structures_graph(delay / 1000.0, batch_size)
 
     # This will create the details file as a side-effect, if specified.
     change_plan = ChangePlan.create(structures_graph, retain, details)

--- a/tubular/tests/test_splitmongo.py
+++ b/tubular/tests/test_splitmongo.py
@@ -371,7 +371,7 @@ class TestSplitMongoBackend(unittest.TestCase):
 
     def test_structures_graph(self):
         """Test pulling a full graph out."""
-        graph = self.backend.structures_graph()
+        graph = self.backend.structures_graph(0, 100)
         self.assertEqual(
             graph.branches,
             [
@@ -412,7 +412,7 @@ class TestSplitMongoBackend(unittest.TestCase):
             ),
             delay=0
         )
-        graph = self.backend.structures_graph()
+        graph = self.backend.structures_graph(0, 100)
         self.assertEqual(
             list(graph.structures.keys()),
             [str_id(i) for i in [1, 4, 10, 11, 20]]
@@ -434,9 +434,9 @@ class TestSplitMongoBackend(unittest.TestCase):
         # Get the real method before we patch it...
         real_all_structures_fn = SplitMongoBackend._all_structures  # pylint: disable=protected-access
 
-        def add_structures(backend):
+        def add_structures(backend, delay, batch_size):
             """Do what _all_structures() would do, then add new Structures."""
-            structures = real_all_structures_fn(backend)
+            structures = real_all_structures_fn(backend, delay, batch_size)
 
             # Create new Structures
             self.structures.insert_one(
@@ -475,7 +475,7 @@ class TestSplitMongoBackend(unittest.TestCase):
 
         with patch.object(SplitMongoBackend, '_all_structures', autospec=True) as all_structures_mock:
             all_structures_mock.side_effect = add_structures
-            graph = self.backend.structures_graph()
+            graph = self.backend.structures_graph(0, 100)
             self.assertEqual(len(graph.structures), 10)
             self.assertEqual(len(graph.branches), 4)
 


### PR DESCRIPTION
This is to allow us to throttle reads which were causing MongoDB instability.

@feanil, @jdmulloy: Review please?