### PR TITLE
Coryleeio/fix retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Please do not report security issues in public. Please email security@edx.org.
 | ASGARD_API_TOKEN     | dummy-token                     | String - The asgard token                                                                     |
 | ASGARD_WAIT_TIMEOUT  | 600                             | Integer - time in seconds to wait for an action such as instances healthy in a load balancer. |
 | REQUESTS_TIMEOUT     | 10                              | How long to wait for an http connection/response from Asgard.                                 |
-| RETRY_MAX_ATTEMPTS   | 5                               | Maximum number attempts to be made when asgard returns a 400 or 500 response.            |
+| RETRY_MAX_ATTEMPTS   | 5                               | Maximum number attempts to be made when asgard returns an error.            |
 | RETRY_DELAY_SECONDS  | 5                               | How long in seconds to wait between retries to asgard                                         |
 | RETRY_MAX_TIME_SECONDS | None                          | How long in seconds to keep retrying asgard before giving up.                                 |
 | RETRY_FACTOR         | 1.5                             | Factor to multiple the base wait time by per retry attempt.  Only applies to ec2 boto calls   |

--- a/tubular/asgard.py
+++ b/tubular/asgard.py
@@ -581,12 +581,6 @@ def elbs_for_asg(asg):
     return elbs
 
 
-@backoff.on_exception(backoff.expo,
-                      (RateLimitedException,
-                       TimeoutException,
-                       BackendError,
-                       ASGDoesNotExistException),
-                      max_tries=MAX_ATTEMPTS)
 def rollback(current_clustered_asgs, rollback_to_clustered_asgs, ami_id=None):
     """
     Rollback to a particular list of ASGs for one or more clusters.
@@ -670,12 +664,6 @@ def rollback(current_clustered_asgs, rollback_to_clustered_asgs, ami_id=None):
         }
 
 
-@backoff.on_exception(backoff.expo,
-                      (RateLimitedException,
-                       TimeoutException,
-                       BackendError,
-                       ASGDoesNotExistException),
-                      max_tries=MAX_ATTEMPTS)
 def deploy(ami_id):
     """
     Deploys an AMI as an auto-scaling group (ASG) to AWS.

--- a/tubular/asgard.py
+++ b/tubular/asgard.py
@@ -53,7 +53,7 @@ LOG = logging.getLogger(__name__)
 MAX_ATTEMPTS = int(os.environ.get('RETRY_MAX_ATTEMPTS', 5))
 
 
-def handle_throttling(json_response):
+def _handle_throttling(json_response):
     """
     Throw an exception if AWS is throttling Asgard
 
@@ -79,7 +79,7 @@ def _parse_asgard_json_response(url, response):
     except ValueError:
         msg = "Expected json response from url: '{}' - but got the following:\n{}"
         raise BackendError(msg.format(url, response.text))
-    handle_throttling(response_json)
+    _handle_throttling(response_json)
     return response_json
 
 

--- a/tubular/asgard.py
+++ b/tubular/asgard.py
@@ -177,9 +177,6 @@ def asgs_for_cluster(cluster):
     return asgs_json
 
 
-@backoff.on_exception(backoff.expo,
-                      (RateLimitedException),
-                      max_tries=MAX_ATTEMPTS)
 def wait_for_task_completion(task_url, timeout):
     """
     Arguments:

--- a/tubular/asgard.py
+++ b/tubular/asgard.py
@@ -10,11 +10,11 @@ import logging
 import time
 import copy
 from collections import defaultdict
+import backoff
 import requests
 import six
 import tubular.ec2 as ec2
 
-from tubular.utils.retry import retry
 from tubular.exception import (
     ASGCountZeroException,
     ASGDoesNotExistException,
@@ -29,6 +29,7 @@ from tubular.exception import (
     MultipleImagesFoundException,
     ResourceDoesNotExistException,
     TimeoutException,
+    RateLimitedException,
 )
 from tubular.utils import WAIT_SLEEP_TIME, DISABLE_OLD_ASG_WAIT_TIME
 
@@ -49,6 +50,24 @@ CLUSTER_INFO_URL = "{}/cluster/show/{}.json".format(ASGARD_API_ENDPOINT, "{}")
 
 LOG = logging.getLogger(__name__)
 
+MAX_ATTEMPTS = os.environ.get('RETRY_MAX_ATTEMPTS', 5)
+
+
+def handle_throttling(json_response):
+    """
+    Throw an exception if AWS is throttling Asgard
+
+    Raises:
+    RateLimitedException: When we are being rate limited by AWS.
+    """
+    if ('status' in json_response and
+            json_response['status'] == 'failed' and
+            json_response['log']):
+
+        last_log_entry = json_response['log'][len(json_response['log']) - 1]
+        if 'com.amazonaws.AmazonServiceException' in last_log_entry and 'Throttling' in last_log_entry:
+            raise RateLimitedException("AWS is throttling requests from Asgard")
+
 
 def _parse_json(url, response):
     """
@@ -62,7 +81,10 @@ def _parse_json(url, response):
     return response_json
 
 
-@retry()
+@backoff.on_exception(backoff.expo,
+                      (RateLimitedException,
+                       BackendDataError),
+                      max_tries=MAX_ATTEMPTS)
 def clusters_for_asgs(asgs):
     """
     An autoscaling group can belong to multiple clusters potentially.
@@ -94,6 +116,7 @@ def clusters_for_asgs(asgs):
     Raises:
         BackendDataError: We got bad data from the backend. We can't
             get cluster information from it.
+        RateLimitedException: When we are being rate limited by AWS.
     """
 
     request = requests.Request('GET', CLUSTER_LIST_URL, params=ASGARD_API_TOKEN)
@@ -101,6 +124,7 @@ def clusters_for_asgs(asgs):
     LOG.debug("Getting Cluster List from: {}".format(url))
     response = requests.get(CLUSTER_LIST_URL, params=ASGARD_API_TOKEN, timeout=REQUESTS_TIMEOUT)
     cluster_json = _parse_json(url, response)
+    handle_throttling(cluster_json)
 
     relevant_clusters = {}
     for cluster in cluster_json:
@@ -119,7 +143,10 @@ def clusters_for_asgs(asgs):
     return relevant_clusters
 
 
-@retry()
+@backoff.on_exception(backoff.expo,
+                      (RateLimitedException,
+                       BackendDataError),
+                      max_tries=MAX_ATTEMPTS)
 def asgs_for_cluster(cluster):
     """
     Given a named cluster, get all ASGs in the cluster.
@@ -129,23 +156,30 @@ def asgs_for_cluster(cluster):
 
     Returns:
         list(dict): List of ASGs.
+
+    Raises:
+        RateLimitedException: When we are being rate limited by AWS.
     """
 
     LOG.debug("URL: {}".format(CLUSTER_INFO_URL.format(cluster)))
     url = CLUSTER_INFO_URL.format(cluster)
     response = requests.get(url, params=ASGARD_API_TOKEN, timeout=REQUESTS_TIMEOUT)
-
     LOG.debug("ASGs for Cluster: {}".format(response.text))
-    asgs = _parse_json(url, response)
+    asgs_json = _parse_json(url, response)
+    handle_throttling(asgs_json)
 
-    if len(asgs) < 1:
+    if len(asgs_json) < 1:
         msg = "Expected a list of dicts with an 'autoScalingGroupName' attribute. " \
-              "Got: {}".format(asgs)
+              "Got: {}".format(asgs_json)
         raise BackendDataError(msg)
 
-    return asgs
+    return asgs_json
 
 
+@backoff.on_exception(backoff.expo,
+                      (RateLimitedException,
+                       TimeoutException),
+                      max_tries=MAX_ATTEMPTS)
 def wait_for_task_completion(task_url, timeout):
     """
     Arguments:
@@ -158,6 +192,7 @@ def wait_for_task_completion(task_url, timeout):
 
     Raises:
         TimeoutException: When we timeout waiting for the task to finish.
+        RateLimitedException: When we are being rate limited by AWS.
     """
 
     if not task_url.endswith('.json'):
@@ -168,6 +203,7 @@ def wait_for_task_completion(task_url, timeout):
     while end_time > datetime.utcnow():
         response = requests.get(task_url, params=ASGARD_API_TOKEN, timeout=REQUESTS_TIMEOUT)
         json_response = _parse_json(task_url, response)
+        handle_throttling(json_response)
         if json_response['status'] in ('completed', 'failed'):
             return json_response
 
@@ -176,6 +212,9 @@ def wait_for_task_completion(task_url, timeout):
     raise TimeoutException("Timed out while waiting for task {}".format(task_url))
 
 
+@backoff.on_exception(backoff.expo,
+                      (RateLimitedException),
+                      max_tries=MAX_ATTEMPTS)
 def new_asg(cluster, ami_id):
     """
     Create a new ASG in the given asgard cluster using the given AMI.
@@ -193,6 +232,7 @@ def new_asg(cluster, ami_id):
         TimeoutException: When the task to bring up the new ASG times out.
         BackendError: When the task to bring up the new ASG fails.
         ASGCountZeroException: When the new ASG brought online has 0 for it's min and desired counts
+        RateLimitedException: When we are being rate limited by AWS.
     """
     payload = {
         "name": cluster,
@@ -218,6 +258,7 @@ def new_asg(cluster, ami_id):
     response = wait_for_task_completion(response.url, ASGARD_NEW_ASG_CREATION_TIMEOUT)
     if response['status'] == 'failed':
         msg = "Failure during new ASG creation. Task Log: \n{}".format(response['log'])
+        handle_throttling(response)
         raise BackendError(msg)
 
     # Potential Race condition if multiple people are making ASGs for the same cluster
@@ -234,11 +275,23 @@ def new_asg(cluster, ami_id):
     return newest_asg['autoScalingGroupName']
 
 
-@retry()
+@backoff.on_exception(backoff.expo,
+                      (RateLimitedException,
+                       TimeoutException,
+                       BackendError,
+                       ASGCountZeroException),
+                      max_tries=MAX_ATTEMPTS)
 def _get_asgard_resource_info(url):
     """
     A generic function for querying Asgard for inforamtion about a specific resource,
     such as an Autoscaling Group, A cluster.
+
+
+    Raises:
+        TimeoutException: When the task to bring up the new ASG times out.
+        BackendError: When the task to bring up the new ASG fails.
+        ASGCountZeroException: When the new ASG brought online has 0 for it's min and desired counts
+        RateLimitedException: When we are being rate limited by AWS.
     """
 
     LOG.debug("URL: {}".format(url))
@@ -251,9 +304,10 @@ def _get_asgard_resource_info(url):
     elif response.status_code != 200:
         raise BackendError('Call to asgard failed with status code: {0}: {1}'
                            .format(response.status_code, response.text))
-
     LOG.debug("ASG info: {}".format(response.text))
-    return _parse_json(url, response)
+    resource_info_json = _parse_json(url, response)
+    handle_throttling(resource_info_json)
+    return resource_info_json
 
 
 def get_asg_info(asg):
@@ -371,7 +425,11 @@ def is_last_asg(asg):
     return False
 
 
-@retry()
+@backoff.on_exception(backoff.expo,
+                      (RateLimitedException,
+                       TimeoutException,
+                       BackendError),
+                      max_tries=MAX_ATTEMPTS)
 def enable_asg(asg):
     """
     Enable an ASG in asgard.  This means it will have ELBs routing to it
@@ -384,7 +442,9 @@ def enable_asg(asg):
         None: When the asg has been enabled.
 
     Raises:
-        TimeoutException: If the task to enable the ASG fails.
+        BackendError: If the task to enable the ASG fails.
+        TimeoutException: If the request to enable the ASG times out
+        RateLimitedException: When we are being rate limited by AWS.
     """
     payload = {"name": asg}
     response = requests.post(
@@ -398,7 +458,11 @@ def enable_asg(asg):
         raise BackendError(msg)
 
 
-@retry()
+@backoff.on_exception(backoff.expo,
+                      (RateLimitedException,
+                       TimeoutException,
+                       BackendError),
+                      max_tries=MAX_ATTEMPTS)
 def disable_asg(asg):
     """
     Disable an ASG using asgard.
@@ -411,10 +475,11 @@ def disable_asg(asg):
         None: When the asg has been disabled.
 
     Raises:
-        TimeoutException: If the task to enable the ASG fails..
+        TimeoutException: If the task to enable the ASG times out
         BackendError: If asgard was unable to disable the ASG
         ASGDoesNotExistException: If the ASG does not exist
         CannotDisableActiveASG: if the current ASG is active
+        RateLimitedException: When we are being rate limited by AWS.
     """
     try:
         if is_asg_pending_delete(asg):
@@ -440,7 +505,11 @@ def disable_asg(asg):
         raise BackendError(msg)
 
 
-@retry()
+@backoff.on_exception(backoff.expo,
+                      (RateLimitedException,
+                       TimeoutException,
+                       BackendError),
+                      max_tries=MAX_ATTEMPTS)
 def delete_asg(asg, fail_if_active=True, fail_if_last=True):
     """
     Delete an ASG using asgard.
@@ -456,6 +525,7 @@ def delete_asg(asg, fail_if_active=True, fail_if_last=True):
         TimeoutException: If the task to delete the ASG fails...
         BackendError: If asgard was unable to delete the ASG
         ASGDoesNotExistException: When an ASG does not exist
+        RateLimitedException: When we are being rate limited by AWS.
     """
     if is_asg_pending_delete(asg):
         LOG.info("Not deleting ASG {} due to its already pending deletion.".format(asg))
@@ -480,7 +550,10 @@ def delete_asg(asg, fail_if_active=True, fail_if_last=True):
         raise BackendError(msg)
 
 
-@retry()
+@backoff.on_exception(backoff.expo,
+                      (RateLimitedException,
+                       BackendDataError),
+                      max_tries=MAX_ATTEMPTS)
 def elbs_for_asg(asg):
     """
     Return the ELB(s) which are directing traffic to a particular ASG.
@@ -492,11 +565,13 @@ def elbs_for_asg(asg):
         list(str): List of the ELB names.
 
     Raises:
-        BackendError: If unexpected response from Asgard.
+        BackendDataError: If unexpected response from Asgard.
+        RateLimitedException: When we are being rate limited by AWS.
     """
     url = ASG_INFO_URL.format(asg)
     response = requests.get(url, params=ASGARD_API_TOKEN, timeout=REQUESTS_TIMEOUT)
     resp_json = _parse_json(url, response)
+    handle_throttling(resp_json)
     try:
         elbs = resp_json['group']['loadBalancerNames']
     except (KeyError, TypeError):
@@ -506,6 +581,12 @@ def elbs_for_asg(asg):
     return elbs
 
 
+@backoff.on_exception(backoff.expo,
+                      (RateLimitedException,
+                       TimeoutException,
+                       BackendError,
+                       ASGDoesNotExistException),
+                      max_tries=MAX_ATTEMPTS)
 def rollback(current_clustered_asgs, rollback_to_clustered_asgs, ami_id=None):
     """
     Rollback to a particular list of ASGs for one or more clusters.
@@ -589,6 +670,12 @@ def rollback(current_clustered_asgs, rollback_to_clustered_asgs, ami_id=None):
         }
 
 
+@backoff.on_exception(backoff.expo,
+                      (RateLimitedException,
+                       TimeoutException,
+                       BackendError,
+                       ASGDoesNotExistException),
+                      max_tries=MAX_ATTEMPTS)
 def deploy(ami_id):
     """
     Deploys an AMI as an auto-scaling group (ASG) to AWS.

--- a/tubular/exception.py
+++ b/tubular/exception.py
@@ -58,3 +58,7 @@ class ASGCountZeroException(Exception):
 
 class InvalidUrlException(Exception):
     pass
+
+
+class RateLimitedException(Exception):
+    pass

--- a/tubular/tests/test_asgard.py
+++ b/tubular/tests/test_asgard.py
@@ -318,14 +318,20 @@ RUNNING_SAMPLE_TASK = {
 AWS_RATE_LIMIT_EXCEPTION = {
     "log":
     [
-        "2017-10-18_16:14:34 Started on thread Task:Creating auto scaling group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271', min 15, max 15, traffic prevented.",
+        (
+            "2017-10-18_16:14:34 Started on thread Task:Creating auto scaling group "
+            "'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271', min 15, max 15, traffic prevented."
+        ),
         "2017-10-18_16:14:34 Group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271' will start with 0 instances",
         "2017-10-18_16:14:34 Create Auto Scaling Group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271'",
-        "2017-10-18_16:14:34 Create Launch Configuration 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271-20171018161434' with image 'ami-abbf6fd1'",
+        ("2017-10-18_16:14:34 Create Launch Configuration "
+            "'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271-20171018161434' with image 'ami-abbf6fd1'"),
         "2017-10-18_16:14:34 Create Autoscaling Group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271'",
-        "2017-10-18_16:14:35 Disabling adding instances to ELB for auto scaling group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271'",
+        ("2017-10-18_16:14:35 Disabling adding instances "
+            "to ELB for auto scaling group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271'"),
         (
-            "2017-10-18_16:14:35 Launch Config 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271-20171018161434' has been created. "
+            "2017-10-18_16:14:35 Launch Config "
+            "'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271-20171018161434' has been created. "
             "Auto Scaling Group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271' has been created. "
         ),
         '2017-10-18_16:14:35 Create 2 Scaling Policies',
@@ -336,7 +342,8 @@ AWS_RATE_LIMIT_EXCEPTION = {
         "2017-10-18_16:14:36 Resizing group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271' to min 15, max 15",
         "2017-10-18_16:14:36 Setting group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271' to min 15 max 15",
         "2017-10-18_16:14:36 Update Autoscaling Group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271'",
-        "2017-10-18_16:14:36 Group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271' has 0 instances. Waiting for 15 to exist.",
+        ("2017-10-18_16:14:36 Group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271'"
+        " has 0 instances. Waiting for 15 to exist."),
         (
         '2017-10-18_16:19:11 Exception: com.amazonaws.AmazonServiceException: Rate exceeded (Service: '
         'AmazonAutoScaling; Status Code: 400; Error Code: Throttling; Request ID: 1324046b-b420-11e7-a9eb-7fe7ac63f645)'
@@ -836,51 +843,6 @@ class TestAsgard(unittest.TestCase):
         )
 
         self.assertRaises(CannotDeleteLastASG, asgard.delete_asg, asg)
-
-    def _setup_common_enable_disable_asg_mock_calls(self, req_mock, asg, test_function, endpoint_url):
-        task_url = "http://some.host/task/1234.json"
-        cluster = "app_cluster"
-
-        req_mock.post(
-            endpoint_url,
-            json=AWS_RATE_LIMIT_EXCEPTION,
-            status_code=200
-        )
-
-        req_mock.get(
-            endpoint_url,
-            json=AWS_RATE_LIMIT_EXCEPTION,
-            status_code=200
-        )
-
-        req_mock.get(
-            asgard.ASG_INFO_URL.format(asg),
-            json=enabled_asg(asg)
-        )
-
-        req_mock.get(
-            asgard.CLUSTER_INFO_URL.format(cluster),
-            json=VALID_CLUSTER_JSON_INFO
-        )
-
-        req_mock.get(
-            task_url,
-            json=COMPLETED_SAMPLE_TASK
-        )
-
-    def test_enable_asg_aws_rate_limit(self, req_mock):
-        endpoint_url = asgard.ASG_ACTIVATE_URL
-        asg = "loadtest-edx-edxapp-v059"
-        test_function = asgard.enable_asg
-        self._setup_common_enable_disable_asg_mock_calls(req_mock, asg, test_function, endpoint_url)
-        self.assertRaises(RateLimitedException, test_function, asg)
-
-    def test_disable_asg_aws_rate_limit(self, req_mock):
-        endpoint_url = asgard.ASG_DEACTIVATE_URL
-        asg = "loadtest-edx-edxapp-v059"
-        test_function = asgard.disable_asg
-        self._setup_common_enable_disable_asg_mock_calls(req_mock, asg, test_function, endpoint_url)
-        self.assertRaises(RateLimitedException, test_function, asg)
 
     @mock_autoscaling
     @mock_ec2

--- a/tubular/tests/test_asgard.py
+++ b/tubular/tests/test_asgard.py
@@ -17,7 +17,6 @@ from moto.ec2.utils import random_ami_id
 from six.moves import urllib, reload_module
 import tubular.asgard as asgard
 from tubular.exception import (
-    TimeoutException,
     BackendError,
     CannotDeleteActiveASG,
     CannotDeleteLastASG,
@@ -325,10 +324,10 @@ AWS_RATE_LIMIT_EXCEPTION = {
         "2017-10-18_16:14:34 Group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271' will start with 0 instances",
         "2017-10-18_16:14:34 Create Auto Scaling Group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271'",
         ("2017-10-18_16:14:34 Create Launch Configuration "
-            "'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271-20171018161434' with image 'ami-abbf6fd1'"),
+         "'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271-20171018161434' with image 'ami-abbf6fd1'"),
         "2017-10-18_16:14:34 Create Autoscaling Group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271'",
         ("2017-10-18_16:14:35 Disabling adding instances "
-            "to ELB for auto scaling group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271'"),
+         "to ELB for auto scaling group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271'"),
         (
             "2017-10-18_16:14:35 Launch Config "
             "'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271-20171018161434' has been created. "
@@ -343,10 +342,11 @@ AWS_RATE_LIMIT_EXCEPTION = {
         "2017-10-18_16:14:36 Setting group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271' to min 15 max 15",
         "2017-10-18_16:14:36 Update Autoscaling Group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271'",
         ("2017-10-18_16:14:36 Group 'stage-mckinsey-EdxappServerAsGroup-BX9JH5ALH5PD-v271'"
-        " has 0 instances. Waiting for 15 to exist."),
+         " has 0 instances. Waiting for 15 to exist."),
         (
-        '2017-10-18_16:19:11 Exception: com.amazonaws.AmazonServiceException: Rate exceeded (Service: '
-        'AmazonAutoScaling; Status Code: 400; Error Code: Throttling; Request ID: 1324046b-b420-11e7-a9eb-7fe7ac63f645)'
+            '2017-10-18_16:19:11 Exception: com.amazonaws.AmazonServiceException: Rate exceeded (Service: '
+            'AmazonAutoScaling; Status Code: 400; Error Code: '
+            'Throttling; Request ID: 1324046b-b420-11e7-a9eb-7fe7ac63f645)'
         )
     ],
     "status": "failed",

--- a/tubular/utils/retry.py
+++ b/tubular/utils/retry.py
@@ -72,11 +72,11 @@ class LifecycleManager(object):
         """
         if max_attempts < 1:
             raise RetryException(
-                "Must specify a max_attempts number greater than 1. Value: {0}".format(max_attempts))
+                "Must specify a max_attempts number greater than or equal to 1. Value: {0}".format(max_attempts))
 
         if delay_seconds < 0:
             raise RetryException(
-                "Must specify a delay_seconds number greater than 0. Value: {0}".format(delay_seconds))
+                "Must specify a delay_seconds number greater than or equal to 0. Value: {0}".format(delay_seconds))
 
         if max_time_seconds is not None and max_time_seconds > delay_seconds:
             LOG.warning(


### PR DESCRIPTION
To summarize - The old retry logic catches all exceptions and retries, so I left the retry logic in places where it was before, the main changes in behaviour were a specific few methods.  these methods were rollback, deploy, and wait_for_task_completion, and new_asg

I have removed the additional retry logic around rollback and deploy, as it can cause these steps to repeat during red_black_deploy and additional infrastructure to be created.  I left the logic around new_asg, as it only repeats when the new rate limiting exception.  For wait_for_task_completion I now only retry if you are throttled, not if you have timed out, as timeouts are often a task failure.
