### PR TITLE
upgrade gitpython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click-log==0.1.8
 edx-opaque-keys==0.4.0
 enum34 >=1.1.6, <2.0; python_version < '3.4'
 freezegun==0.3.8
-GitPython==2.1.1
+GitPython==2.1.8
 jenkinsapi==0.3.3
 lxml >= 3.7, <3.8
 PyGithub==1.29


### PR DESCRIPTION
This older version of gitpython has a bug with the latest release of git, causing failures.  See https://github.com/gitpython-developers/GitPython/issues/687