### PR TITLE
Remove the restriction on override + edp

### DIFF
--- a/tubular/scripts/retrieve_base_ami.py
+++ b/tubular/scripts/retrieve_base_ami.py
@@ -52,12 +52,8 @@ def retrieve_base_ami(environment, deployment, play, override, out_file):
     """
 
     has_edp = environment is not None or deployment is not None or play is not None
-    if has_edp and override is not None:
-        logging.error("--environment, --deployment and --play are mutually exclusive with --override.")
-        sys.exit(1)
-
-    if not has_edp and override is None:
-        logging.error("Either --environment, --deployment and --play or --override are required.")
+    if not has_edp:
+        logging.error("Specify --environment, --deployment and --play.")
         sys.exit(1)
 
     try:


### PR DESCRIPTION
We need the EDP all the time because we now fetch tags on running AMIs even when building from scratch / overridden AMI

This may work out interesting in the future if --override is ever used for something other than building from scratch, but we'll figure that out later.

https://github.com/edx/tubular/pull/213