### PR TITLE
Pass through the status url as well.

### DIFF
--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -303,11 +303,12 @@ class GitHubAPI(object):
 
         # Determine if the commit has passed all checks
         if len(commit_status.statuses) < 1 or commit_status.state is None:
-            return (False, {})
+            return (False, {}, "")
 
         return (
             commit_status.state.lower() == 'success',
-            {cs.context: cs.target_url for cs in commit_status.statuses}
+            {cs.context: cs.target_url for cs in commit_status.statuses},
+            commit_status.url
         )
 
     def check_combined_status_commit(self, commit_sha):

--- a/tubular/scripts/check_pr_tests_status.py
+++ b/tubular/scripts/check_pr_tests_status.py
@@ -95,18 +95,20 @@ def check_tests(org,
     if input_file:
         input_vars = yaml.safe_load(io.open(input_file, 'r'))
         pr_number = input_vars['pr_number']
-        status_success, test_statuses = gh_utils.check_combined_status_pull_request(pr_number)
+        status_success, test_statuses, combined_status_url = gh_utils.check_combined_status_pull_request(pr_number)
         git_obj = 'PR #{}'.format(pr_number)
     elif pr_number:
-        status_success, test_statuses = gh_utils.check_combined_status_pull_request(pr_number)
+        status_success, test_statuses, combined_status_url = gh_utils.check_combined_status_pull_request(pr_number)
         git_obj = 'PR #{}'.format(pr_number)
     elif commit_hash:
-        status_success, test_statuses = gh_utils.check_combined_status_commit(commit_hash)
+        status_success, test_statuses, combined_status_url = gh_utils.check_combined_status_commit(commit_hash)
         git_obj = 'commit hash {}'.format(commit_hash)
 
     LOG.info("{}: Combined status of {} is {}.".format(
         sys.argv[0], git_obj, "success" if status_success else "failed"
     ))
+    LOG.info("{}: Combined status url: {}".format(
+        sys.argv[0], combined_status_url))
 
     dirname = os.path.dirname(out_file.name)
     if dirname:

--- a/tubular/tests/test_github.py
+++ b/tubular/tests/test_github.py
@@ -248,25 +248,27 @@ class GitHubApiTestCase(TestCase):
         self.assertEqual(self.api.have_branches_diverged('base', 'head'), expected)
 
     @ddt.data(
-        ('123', list(range(10)), 10, 'SuCcEsS', True),
-        ('123', list(range(10)), 10, 'success', True),
-        ('123', list(range(10)), 10, 'SUCCESS', True),
-        ('123', list(range(10)), 10, 'pending', False),
-        ('123', list(range(10)), 10, 'failure', False),
-        ('123', list(range(10)), 0, None, False)
+        ('123', list(range(10)), 10, 'SuCcEsS', True, "dummy_url"),
+        ('123', list(range(10)), 10, 'success', True, "dummy_url"),
+        ('123', list(range(10)), 10, 'SUCCESS', True, "dummy_url"),
+        ('123', list(range(10)), 10, 'pending', False, "dummy_url"),
+        ('123', list(range(10)), 10, 'failure', False, "dummy_url"),
+        ('123', list(range(10)), 0, None, False, "")
     )
     @ddt.unpack
-    def test_check_combined_status_commit(self, sha, statuses, statuses_returned, state, expected):
+    def test_check_combined_status_commit(self, sha, statuses, statuses_returned, state, expected, combined_url):
         mock_combined_status = Mock(spec=CommitCombinedStatus)
         mock_combined_status.statuses = [Mock(spec=CommitStatus, id=i) for i in statuses]
         mock_combined_status.state = state
+        mock_combined_status.url = combined_url
 
         commit_mock = Mock(spec=Commit)
         commit_mock.get_combined_status.return_value = mock_combined_status
         self.repo_mock.get_commit.return_value = commit_mock
 
-        response, statuses = self.api.check_combined_status_commit(sha)
+        response, statuses, commit_url = self.api.check_combined_status_commit(sha)
 
+        self.assertEqual(commit_url, combined_url)
         self.assertEqual(response, expected)
         self.assertIsInstance(statuses, dict)
         self.assertEqual(len(statuses), statuses_returned)


### PR DESCRIPTION
It's nice to actually have the url because it's easier to read that than going to each job link.  Since usually when this fails you want to know which of the contexts failed.

Sample output:
```
INFO:tubular.scripts.check_pr_tests_status:/home/feanil/.virtualenvs/tubular/bin/check_pr_tests_statu
s.py: Combined status of commit hash 1b4ac84141745146f72d6321ddc3b9a2882d96b3 is failed.             
INFO:tubular.scripts.check_pr_tests_status:/home/feanil/.virtualenvs/tubular/bin/check_pr_tests_statu
s.py: Combined status url: https://api.github.com/repos/edx/edx-platform/commits/1b4ac84141745146f72d
6321ddc3b9a2882d96b3/status                                                       
{jenkins/a11y: 'https://build.testeng.edx.org/job/edx-platform-accessibility-master/6469/',
  jenkins/bokchoy: 'https://build.testeng.edx.org/job/edx-platform-bok-choy-master/8424/',           
  jenkins/django-upgrade/python: 'https://build.testeng.edx.org/job/edx-platform-django-upgrade-unitt
ests-master/284/',                                                                   
  jenkins/js: 'https://build.testeng.edx.org/job/edx-platform-js-master/6226/', jenkins/lettuce: 'htt
ps://build.testeng.edx.org/job/edx-platform-lettuce-master/9367/',                                   
  jenkins/python: 'https://build.testeng.edx.org/job/edx-platform-python-unittests-master/8715/',
  jenkins/quality: 'https://build.testeng.edx.org/job/edx-platform-quality-flow-master/245/'} 
```