### PR TITLE
Fix an issue with handling retiring users without forum accounts

### DIFF
--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -123,11 +123,8 @@ class LmsApi(BaseApiClient):
         params = {'data': {'username': learner['original_username']}}
         try:
             return self._client.api.discussion.v1.accounts.retire_forum.post(**params)
-        except HttpNotFoundError as exc:
-            if "User not found" in text_type(exc):
-                print("User not found in forums, this is expected sometimes. Overriding to success.")
-                return True
-            raise
+        except HttpNotFoundError:
+            return True
 
     def retirement_retire_mailings(self, learner):
         """


### PR DESCRIPTION
https://openedx.atlassian.net/browse/PLAT-2141
Forums will 404, which will trigger an LMS 404. The string checking
in place previously didn't work, likely a Py2 vs Py3 thing, this just
simplifies the check to make sure this case gets caught.