### PR TITLE
Remove deletion tags from ASGs that should not be removed.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Elton Carr, II <eltonc@microsoft.com>
 Feanil Patel <feanil@edx.org>
 Fred Smith <derf@edx.org>
 Gregory Martin <greg@edx.org>
+Gregory Martin <yro@users.noreply.github.com>
 J Eskew <jeskew@edx.org>
 Jesse Zoldak <zoldak@edx.org>
 John Eskew <jeskew@edx.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,12 @@
 CHANGES
 =======
 
-* Update
-* Update tests
-* Update
+* Remove deletion tags from ASGs that should not be removed
+* Relax Sailthru retire retry to be any non-500 error
+* Fix hard coded states to fetch retirement users for (#228)
+* Move static methods outside of class to work properly
+* Add retry logic around mailing retirement call
+* Add lms\_retire\_misc endpoint to edx\_api (#225)
 * Update script checkstep
 * Fix an issue with handling retiring users without forum accounts (#223)
 * Move the retirement pipeline definition to the config file (#222)

--- a/tubular/tests/test_asgard.py
+++ b/tubular/tests/test_asgard.py
@@ -821,7 +821,8 @@ class TestAsgard(unittest.TestCase):
             asgard.ASG_DELETE_URL,
             json=post_callback
         )
-        self.assertRaises(CannotDeleteActiveASG, asgard.delete_asg, asg, True)
+        with mock.patch("tubular.ec2.remove_asg_deletion_tag"):
+            self.assertRaises(CannotDeleteActiveASG, asgard.delete_asg, asg, True)
 
     def test_delete_asg_pending_delete(self, req_mock):
         asg = "loadtest-edx-edxapp-v060"
@@ -843,7 +844,8 @@ class TestAsgard(unittest.TestCase):
             json=VALID_SINGLE_ASG_CLUSTER_INFO_JSON
         )
 
-        self.assertRaises(CannotDeleteLastASG, asgard.delete_asg, asg)
+        with mock.patch("tubular.ec2.remove_asg_deletion_tag"):
+            self.assertRaises(CannotDeleteLastASG, asgard.delete_asg, asg)
 
     @mock_autoscaling
     @mock_ec2


### PR DESCRIPTION
Sometimes the tag remains on an active ASG, and we have to go in and manually delete it.  This should automate that process.