### PR TITLE
Consolidate retirement states to make updates easier

### DIFF
--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -75,20 +75,13 @@ class LmsApi(BaseApiClient):
     """
     LMS API client with convenience methods for making API calls.
     """
-    def learners_to_retire(self, cool_off_days=7):
+    def learners_to_retire(self, states_to_request, cool_off_days=7):
         """
         Retrieves a list of learners awaiting retirement actions.
         """
         params = {
             'cool_off_days': cool_off_days,
-            'states': [
-                'PENDING',
-                'FORUMS_COMPLETE',
-                'EMAIL_LISTS_COMPLETE',
-                'ENROLLMENTS_COMPLETE',
-                'LMS_MISC_COMPLETE',
-                'LMS_COMPLETE',
-            ]
+            'states': states_to_request
         }
         try:
             return self._client.api.user.v1.accounts.retirement_queue.get(**params)

--- a/tubular/scripts/get_learners_to_retire.py
+++ b/tubular/scripts/get_learners_to_retire.py
@@ -48,8 +48,8 @@ def get_learners_to_retire(config_file,
     """
     if not config_file:
         click.echo('A config file is required.')
+        exit(-1)
 
-    # If a config file is present, it overrides all passed-in params.
     with io.open(config_file, 'r') as config:
         config_yaml = yaml.load(config)
 

--- a/tubular/tests/retirement_helpers.py
+++ b/tubular/tests/retirement_helpers.py
@@ -1,0 +1,36 @@
+"""
+Common functionality for retirement related tests
+"""
+
+import yaml
+
+
+TEST_RETIREMENT_PIPELINE = [
+    ['RETIRING_FORUMS', 'FORUMS_COMPLETE', 'LMS', 'retirement_retire_forum'],
+    ['RETIRING_EMAIL_LISTS', 'EMAIL_LISTS_COMPLETE', 'LMS', 'retirement_retire_mailings'],
+    ['RETIRING_ENROLLMENTS', 'ENROLLMENTS_COMPLETE', 'LMS', 'retirement_unenroll'],
+    ['RETIRING_LMS', 'LMS_COMPLETE', 'LMS', 'retirement_lms_retire']
+]
+
+TEST_RETIREMENT_END_STATES = [state[1] for state in TEST_RETIREMENT_PIPELINE]
+TEST_RETIREMENT_QUEUE_STATES = ['PENDING'] + TEST_RETIREMENT_END_STATES
+
+
+def fake_config_file(f):
+    """
+    Create a config file for a single test. Combined with CliRunner.isolated_filesystem() to
+    ensure the file lifetime is limited to the test. See _call_script for usage.
+    """
+
+    config = {
+        'client_id': 'bogus id',
+        'client_secret': 'supersecret',
+        'base_urls': {
+            'credentials': 'https://credentials.stage.edx.org/',
+            'lms': 'https://stage-edx-edxapp.edx.org/',
+            'ecommerce': 'https://ecommerce.stage.edx.org/'
+        },
+        'retirement_pipeline': TEST_RETIREMENT_PIPELINE
+    }
+
+    yaml.safe_dump(config, f)

--- a/tubular/tests/test_edx_api.py
+++ b/tubular/tests/test_edx_api.py
@@ -9,6 +9,7 @@ import unittest
 from mock import patch
 
 import tubular.edx_api as edx_api
+from tubular.tests.retirement_helpers import TEST_RETIREMENT_QUEUE_STATES
 
 
 class TestBaseApiClient(unittest.TestCase):
@@ -66,16 +67,9 @@ class TestLmsApi(unittest.TestCase):
                     'the_client_id',
                     'the_client_secret'
                 )
-                lms_api.learners_to_retire(cool_off_days=365)
+                lms_api.learners_to_retire(TEST_RETIREMENT_QUEUE_STATES, cool_off_days=365)
                 # pylint: disable=protected-access
                 lms_api._client.api.user.v1.accounts.retirement_queue.get.assert_called_once_with(
                     cool_off_days=365,
-                    states=[
-                        'PENDING',
-                        'FORUMS_COMPLETE',
-                        'EMAIL_LISTS_COMPLETE',
-                        'ENROLLMENTS_COMPLETE',
-                        'LMS_MISC_COMPLETE',
-                        'LMS_COMPLETE'
-                    ]
+                    states=TEST_RETIREMENT_QUEUE_STATES
                 )

--- a/tubular/tests/test_retire_one_learner.py
+++ b/tubular/tests/test_retire_one_learner.py
@@ -5,7 +5,6 @@ Test the retire_one_learner.py script
 from mock import patch, DEFAULT
 
 from click.testing import CliRunner
-import yaml
 
 from tubular.scripts.retire_one_learner import (
     END_STATES,
@@ -17,31 +16,7 @@ from tubular.scripts.retire_one_learner import (
     ERR_USER_IN_WORKING_STATE,
     retire_learner
 )
-
-
-def _config_file(f):
-    """
-    Create a config file for a single test. Combined with CliRunner.isolated_filesystem() to
-    ensure the file lifetime is limited to the test. See _call_script for usage.
-    """
-
-    config = {
-        'client_id': 'bogus id',
-        'client_secret': 'supersecret',
-        'base_urls': {
-            'credentials': 'https://credentials.stage.edx.org/',
-            'lms': 'https://stage-edx-edxapp.edx.org/',
-            'ecommerce': 'https://ecommerce.stage.edx.org/'
-        },
-        'retirement_pipeline': [
-            ['RETIRING_FORUMS', 'FORUMS_COMPLETE', 'LMS', 'retirement_retire_forum'],
-            ['RETIRING_EMAIL_LISTS', 'EMAIL_LISTS_COMPLETE', 'LMS', 'retirement_retire_mailings'],
-            ['RETIRING_ENROLLMENTS', 'ENROLLMENTS_COMPLETE', 'LMS', 'retirement_unenroll'],
-            ['RETIRING_LMS', 'LMS_COMPLETE', 'LMS', 'retirement_lms_retire']
-        ]
-    }
-
-    yaml.safe_dump(config, f)
+from tubular.tests.retirement_helpers import fake_config_file
 
 
 def _call_script(username):
@@ -52,7 +27,7 @@ def _call_script(username):
     runner = CliRunner()
     with runner.isolated_filesystem():
         with open('test_config.yml', 'w') as f:
-            _config_file(f)
+            fake_config_file(f)
         result = runner.invoke(retire_learner, args=['--username', username, '--config_file', 'test_config.yml'])
     print(result)
     print(result.output)


### PR DESCRIPTION
- Also forces get_learners_to_retire.py to use a config file instead of allowing command line or env var overrides