### PR TITLE
Correctly decode unicode response content

### DIFF
--- a/tubular/scripts/retire_one_learner.py
+++ b/tubular/scripts/retire_one_learner.py
@@ -237,7 +237,9 @@ def retire_learner(
         exc_msg = text_type(exc)
 
         try:
-            exc_msg += '\n' + text_type(exc.content)
+            # Slumber inconveniently discards the decoded .text attribute from the Response object, and instead gives us
+            # the raw encoded .content attribute, so we need to decode it first.
+            exc_msg += '\n' + exc.content.decode('utf-8')
         except AttributeError:
             pass
 


### PR DESCRIPTION
This solves any case where the json response contains unicode which
would throw a UnicodeDecodeError.

---

I was doing end-to-end test of the new notes retirement stage, and ran into this error:

https://build.testeng.edx.org/job/user-retirement-driver/1683/console

```
20:25:08 Traceback (most recent call last):
20:25:08   File "scripts/retire_one_learner.py", line 255, in <module>
20:25:08     retire_learner(auto_envvar_prefix='RETIREMENT')
20:25:08   File "/home/jenkins/shiningpanda/jobs/611e5d7c/virtualenvs/611e5d7c/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
20:25:08     return self.main(*args, **kwargs)
20:25:08   File "/home/jenkins/shiningpanda/jobs/611e5d7c/virtualenvs/611e5d7c/local/lib/python2.7/site-packages/click/core.py", line 697, in main
20:25:08     rv = self.invoke(ctx)
20:25:08   File "/home/jenkins/shiningpanda/jobs/611e5d7c/virtualenvs/611e5d7c/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
20:25:08     return ctx.invoke(self.callback, **ctx.params)
20:25:08   File "/home/jenkins/shiningpanda/jobs/611e5d7c/virtualenvs/611e5d7c/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
20:25:08     return callback(*args, **kwargs)
20:25:08   File "scripts/retire_one_learner.py", line 240, in retire_learner
20:25:08     exc_msg += '\n' + text_type(exc.content)
20:25:08 UnicodeDecodeError: 'ascii' codec can't decode byte 0xd8 in position 24003: ordinal not in range(128)
```

I couldn't see the actual error message since the exception handler failed to decode the unicode error message, I think.