### PR TITLE
Adds a new type of PR message that says the tests failed

### DIFF
--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -31,6 +31,7 @@ PR_ON_STAGE_DATE_MESSAGE = 'in preparation for a release to production on {date:
 PR_ON_PROD_MESSAGE = PR_PREFIX + 'This PR has been deployed to the production environment. {extra_text}'
 PR_RELEASE_CANCELED_MESSAGE = PR_PREFIX + 'This PR has been rolled back from the production environment. {extra_text}'
 PR_BROKE_VAGRANT_DEVSTACK_MESSAGE = PR_PREFIX + 'This PR may have broken Vagrant Devstack CI. {extra_text}'
+PR_E2E_FAILED_MESSAGE = PR_PREFIX + 'This PR may have caused e2e tests to fail on Stage. {extra_text}'
 
 DEFAULT_TAG_USERNAME = 'no_user'
 DEFAULT_TAG_EMAIL_ADDRESS = 'no.public.email@edx.org'
@@ -893,6 +894,27 @@ class GitHubAPI(object):
             pr_number,
             PR_BROKE_VAGRANT_DEVSTACK_MESSAGE.format(extra_text=extra_text),
             PR_BROKE_VAGRANT_DEVSTACK_MESSAGE.format(extra_text=''),
+            force_message
+        )
+
+    def message_pr_e2e_failed(self, pr_number, force_message=False, extra_text=''):
+        """
+
+        Sends a message that this PRs commits have failed one of the e2e tests
+
+        Args:
+            pr_number (int): The number of the pull request
+            force_message (bool): if set true the message will be posted without duplicate checking
+            extra_text (str): Extra text that will be inserted at the end of the PR message
+
+        Returns:
+            github.IssueComment.IssueComment
+
+        """
+        return self.message_pull_request(
+            pr_number,
+            PR_E2E_FAILED_MESSAGE.format(extra_text=extra_text),
+            PR_E2E_FAILED_MESSAGE.format(extra_text=''),
             force_message
         )
 

--- a/tubular/scripts/message_prs_in_range.py
+++ b/tubular/scripts/message_prs_in_range.py
@@ -79,7 +79,10 @@ LOG = logging.getLogger(__name__)
     u'--release_vagrant_broken', u'message_type', flag_value=u'broke_vagrant'
 )
 @click.option(
-    u'--release', u'message_type', type=click.Choice(['stage', 'prod', 'rollback', 'broke_vagrant']),
+    u'--release_e2e_failed', u'message_type', flag_value=u'e2e_failed'
+)
+@click.option(
+    u'--release', u'message_type', type=click.Choice(['stage', 'prod', 'rollback', 'broke_vagrant', 'e2e_failed']),
 )
 @click.option(
     u'--extra_text', u'extra_text', default=''
@@ -196,6 +199,7 @@ def message_prs(api, message_type, pull_request, extra_text):
         u'prod': u'message_pr_deployed_prod',
         u'rollback': u'message_pr_release_canceled',
         u'broke_vagrant': u'message_pr_broke_vagrant',
+        u'e2e_failed': u'message_pr_e2e_failed',
     }
     LOG.info(u"Posting message type %r to %d.", message_type, pull_request.number)
     getattr(api, methods[message_type])(pr_number=pull_request, extra_text=extra_text)


### PR DESCRIPTION
Otherwise this runs after the PR_OD_STAGED_MESSAGE message and
tubular thinks it was a duplicate.

https://github.com/edx/edx-gomatic/pull/416