### PR TITLE
add DriveApi.list_subfolders() for listing partner folders

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ Feanil Patel <feanil@edx.org>
 Fred Smith <derf@edx.org>
 Gregory Martin <greg@edx.org>
 Gregory Martin <yro@users.noreply.github.com>
+Isabel <isabelgk@users.noreply.github.com>
 J Eskew <jeskew@edx.org>
 Jesse Zoldak <zoldak@edx.org>
 John Eskew <jeskew@edx.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,13 @@
 CHANGES
 =======
 
+* changelog and authors maintenance
+* add DriveApi.list\_subfolders() for listing partner folders
+* add the drive.metadata scope for listing drive folders
 * add google\_api.py
+* Adds a new type of PR message that says the tests failed
+* Add partner queue retirement API endpoint to edx\_api (#242)
+* Backoff after hitting API rate limit when messaging PRs (#241)
 * PLAT-2177: Use different backoff for 504 gateway timeout errors. Test both 500 and 504 errors. Update Changelog
 * Force integer inputs to be... integers. (#238)
 * Error if an unexpectedly high number of users are being retired (#236)

--- a/tubular/tests/test_google_api.py
+++ b/tubular/tests/test_google_api.py
@@ -6,6 +6,10 @@ from __future__ import unicode_literals
 import sys
 import unittest
 from io import BytesIO
+import json
+
+import six
+from six.moves import range  # use the range function introduced in python 3
 
 from googleapiclient.http import HttpMockSequence
 
@@ -22,6 +26,28 @@ class TestDriveApi(unittest.TestCase):
     def setUp(self):
         with open(DISCOVERY_DRIVE_RESPONSE_FILE, 'r') as f:
             self.mock_discovery_response_content = f.read()
+
+    @classmethod
+    def _http_mock_sequence_retry(cls):
+        """
+        Returns a tuple, for use in http mock sequences, which represents a response from google suggesting to retry.
+        """
+        return (
+            {'status': '403'},
+            json.dumps({
+                "error": {
+                    "errors": [
+                        {
+                            "domain": "usageLimits",
+                            "reason": "userRateLimitExceeded",
+                            "message": "User Rate Limit Exceeded",
+                        }
+                    ],
+                    "code": 403,
+                    "message": "User Rate Limit Exceeded",
+                }
+            }).encode('utf-8'),
+        )
 
     @patch('tubular.google_api.service_account.Credentials.from_service_account_file', return_value=None)
     def test_create_file_success(self, mock_from_service_account_file):  # pylint: disable=unused-argument
@@ -45,9 +71,8 @@ class TestDriveApi(unittest.TestCase):
         assert response == fake_file_id
 
     @patch('tubular.google_api.service_account.Credentials.from_service_account_file', return_value=None)
-    @patch('tubular.google_api._backoff_handler')
     # pylint: disable=unused-argument
-    def test_create_file_retry_success(self, mock_backoff_handler, mock_from_service_account_file):
+    def test_create_file_retry_success(self, mock_from_service_account_file):
         """
         Test rate limit and retry during file upload.
         """
@@ -56,22 +81,7 @@ class TestDriveApi(unittest.TestCase):
             # First, a request is made to the discovery API to construct a client object for Drive.
             ({'status': '200'}, self.mock_discovery_response_content),
             # Then, a request is made to upload the file while rate limiting was activated.  This should cause a retry.
-            ({'status': '403'},
-             '''
-             {
-              "error": {
-               "errors": [
-                {
-                 "domain": "usageLimits",
-                 "reason": "userRateLimitExceeded",
-                 "message": "User Rate Limit Exceeded"
-                }
-               ],
-               "code": 403,
-               "message": "User Rate Limit Exceeded"
-              }
-             }
-             '''),
+            self._http_mock_sequence_retry(),
             # Finally, success.
             ({'status': '200'}, '{{"id": "{}"}}'.format(fake_file_id)),
         ])
@@ -191,3 +201,88 @@ ETag: "etag/sheep"\r\n\r\n
                 'Successfully deleted file.' in msg
                 for msg in captured_logs.output
             )
+
+    @patch('tubular.google_api.service_account.Credentials.from_service_account_file', return_value=None)
+    def test_list_subfolders_one_page(self, mock_from_service_account_file):  # pylint: disable=unused-argument
+        """
+        Simple case where subfolders are requested, and the response contains one page.
+        """
+        fake_files = [
+            {'id': 'fake-folder-id-{}'.format(idx), 'name': 'fake-folder-name-{}'.format(idx)}
+            for idx in range(10)
+        ]
+        http_mock_sequence = HttpMockSequence([
+            # First, a request is made to the discovery API to construct a client object for Drive.
+            (
+                {'status': '200'},
+                self.mock_discovery_response_content,
+            ),
+            # Then, a request is made to list files.
+            (
+                {'status': '200', 'content-type': 'application/json'},
+                json.dumps({'files': fake_files}).encode('utf-8'),
+            ),
+        ])
+        test_client = DriveApi('non-existent-secrets.json', http=http_mock_sequence)
+        response = test_client.list_subfolders('fake-folder-id')
+        six.assertCountEqual(self, response, fake_files)
+
+    @patch('tubular.google_api.service_account.Credentials.from_service_account_file', return_value=None)
+    def test_list_subfolders_two_page(self, mock_from_service_account_file):  # pylint: disable=unused-argument
+        """
+        Subfolders are requested, but the response is paginated.
+        """
+        fake_files = [
+            {'id': 'fake-folder-id-{}'.format(idx), 'name': 'fake-folder-name-{}'.format(idx)}
+            for idx in range(10)
+        ]
+        fake_files_part_1 = fake_files[:7]
+        fake_files_part_2 = fake_files[7:]
+        http_mock_sequence = HttpMockSequence([
+            # First, a request is made to the discovery API to construct a client object for Drive.
+            (
+                {'status': '200'},
+                self.mock_discovery_response_content,
+            ),
+            # Then, a request is made to list files.  The response contains a nextPageToken suggesting there are more
+            # pages.
+            (
+                {'status': '200', 'content-type': 'application/json'},
+                json.dumps({'files': fake_files_part_1, 'nextPageToken': 'fake-next-page-token'}).encode('utf-8'),
+            ),
+            # Finally, a second list request is made.  This time, no nextPageToken is present in the response,
+            # suggesting there are no more pages.
+            (
+                {'status': '200', 'content-type': 'application/json'},
+                json.dumps({'files': fake_files_part_2}).encode('utf-8'),
+            ),
+        ])
+        test_client = DriveApi('non-existent-secrets.json', http=http_mock_sequence)
+        response = test_client.list_subfolders('fake-folder-id')
+        six.assertCountEqual(self, response, fake_files)
+
+    @patch('tubular.google_api.service_account.Credentials.from_service_account_file', return_value=None)
+    def test_list_subfolders_retry(self, mock_from_service_account_file):  # pylint: disable=unused-argument
+        """
+        Subfolders are requested, but there is rate limiting causing a retry.
+        """
+        fake_files = [
+            {'id': 'fake-folder-id-{}'.format(idx), 'name': 'fake-folder-name-{}'.format(idx)}
+            for idx in range(10)
+        ]
+        http_mock_sequence = HttpMockSequence([
+            # First, a request is made to the discovery API to construct a client object for Drive.
+            (
+                {'status': '200'},
+                self.mock_discovery_response_content),
+            # Then, a request is made to list files, but the response suggests to retry.
+            self._http_mock_sequence_retry(),
+            # Finally, the request is retried, and the response is OK.
+            (
+                {'status': '200', 'content-type': 'application/json'},
+                json.dumps({'files': fake_files}).encode('utf-8'),
+            ),
+        ])
+        test_client = DriveApi('non-existent-secrets.json', http=http_mock_sequence)
+        response = test_client.list_subfolders('fake-folder-id')
+        six.assertCountEqual(self, response, fake_files)


### PR DESCRIPTION
PLAT-2200

---

Manual testing:

```
>>> client.list_subfolders('17E1UoFlhXr3iu8D9yjPBc0pojVZ3hpfZ')
[{'name': 'edX', 'id': '11_eUyyv058zJA7NgHpkwfRnpg1U4jXp3'}]
```

`17E1UoFlhXr3iu8D9yjPBc0pojVZ3hpfZ` is the id of the top level folder for stage partner reporting, and the response is correct since there is only one subfolder.

Also, tests pass locally under python 2.7.