### PR TITLE
Correct the search query for finding approved open PRs.

### DIFF
--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -911,6 +911,6 @@ class GitHubAPI(object):
         """
         Yield all pull requests in the repo against ``pr_base`` that are approved and not closed.
         """
-        query = "review:approved state:open state:merged"
+        query = "review:approved state:open"
         for issue in self.search_issues(query, 'pr', pr_base, '', ''):
             yield self.github_repo.get_pull(issue.number)


### PR DESCRIPTION
This search must have work at some point because it has been like this
for a while.  The search is incorrect because it queries for two
different values of `state` that contradict eachother.

It must have previously taken the first value and done the right thing.
However, it now seems to take the last value and so does not find the
intended open PRs that have been approved.  This change should remove
the ambiguity and correct the search behavior.