### PR TITLE
search github prs using string

### DIFF
--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -574,13 +574,17 @@ class GitHubAPI(object):
         """
 
         try:
-            log_str = 'Performing github search: query: {} type: {} base: {} user: {} repo: {}'
-            LOGGER.info(log_str.format(query, github_type, base, user, repo))
-            return self.github_connection.search_issues(query,
-                                                        type=github_type,
-                                                        base=base,
-                                                        user=user,
-                                                        repo=repo)
+            query_str = [query]
+            if github_type:
+                query_str.append("type:{}".format(github_type))
+            if base:
+                query_str.append("base:{}".format(base))
+            if user:
+                query_str.append("user:{}".format(user))
+            if repo:
+                query_str.append("repo:{}".format(repo))
+            LOGGER.info(' '.join(query_str))
+            return self.github_connection.search_issues(' '.join(query_str))
         except GithubException as exc:
             message = str(exc.data)
             if 'you have triggered an abuse detection mechanism' in message.lower():

--- a/tubular/tests/test_github.py
+++ b/tubular/tests/test_github.py
@@ -321,15 +321,20 @@ class GitHubApiTestCase(TestCase):
         commits = [Mock(spec=Commit, sha=sha) for sha in shas]
         self.repo_mock.compare.return_value = Mock(spec=Comparison, commits=commits)
 
-        def search_issues_side_effect(shas, **kwargs):  # pylint: disable=unused-argument
+        def search_issues_side_effect(query, **kwargs):  # pylint: disable=unused-argument
             """
             Stub implementation of GitHub issue search.
             """
             return [Mock(
                 spec=Issue,
-                number=TRIMMED_SHA_MAP[sha],
+                number=TRIMMED_SHA_MAP[query_item],
                 repository=self.repo_mock,
-            ) for sha in shas.split()]
+            ) for query_item in query.split() if query_item in TRIMMED_SHA_MAP]
+            # The query is all the shas + params to narry the query to PRs and repo.
+            # This shouldn't break the intent of the test because we are still pulling
+            # in all the params that are relevant to this test which are the passed in
+            # shas.  And it's ignoring other parameters that search_issues might add
+            # to the test.
 
         mock_search_issues.side_effect = search_issues_side_effect
 


### PR DESCRIPTION
the github api no longer ignores blank parameters.  We should only specify parameters we want to search on.