### PR TITLE
add the platform name to generated partner report files

### DIFF
--- a/tubular/scripts/retirement_partner_report.py
+++ b/tubular/scripts/retirement_partner_report.py
@@ -143,7 +143,7 @@ def _get_orgs_and_learners_or_exit(config):
         FAIL_EXCEPTION(ERR_FETCHING_LEARNERS, 'Unexpected exception occurred!', exc)
 
 
-def _generate_report_files_or_exit(report_data, output_dir):
+def _generate_report_files_or_exit(config, report_data, output_dir):
     """
     Spins through the partners, creating a single CSV file for each
     """
@@ -158,8 +158,8 @@ def _generate_report_files_or_exit(report_data, output_dir):
         try:
             # Fields for each learner to write, in order these are also the header names
             fields = ['original_username', 'original_email', 'original_name']
-            outfile = os.path.join(output_dir, '{}_{}_{}.csv'.format(
-                REPORTING_FILENAME_PREFIX, partner, date.today().isoformat()
+            outfile = os.path.join(output_dir, '{}_{}_{}_{}.csv'.format(
+                REPORTING_FILENAME_PREFIX, config['partner_report_platform_name'], partner, date.today().isoformat()
             ))
 
             # If there is already a file for this date, assume it is bad and replace it
@@ -301,7 +301,7 @@ def generate_report(config_file, google_secrets_file, output_dir, comments):
         _setup_lms_or_exit(config)
         _config_drive_folder_map_or_exit(config)
         report_data, all_usernames = _get_orgs_and_learners_or_exit(config)
-        partner_filenames = _generate_report_files_or_exit(report_data, output_dir)
+        partner_filenames = _generate_report_files_or_exit(config, report_data, output_dir)
 
         # All files generated successfully, now push them to Google
         report_file_ids = _push_files_to_google(config, partner_filenames)

--- a/tubular/tests/retirement_helpers.py
+++ b/tubular/tests/retirement_helpers.py
@@ -26,6 +26,8 @@ FAKE_ORGS = {
     'org3': 'Org3X',
 }
 
+TEST_PLATFORM_NAME = 'fakename'
+
 
 def fake_config_file(f, orgs=None):
     """
@@ -44,6 +46,7 @@ def fake_config_file(f, orgs=None):
             'ecommerce': 'https://ecommerce.stage.edx.org/'
         },
         'retirement_pipeline': TEST_RETIREMENT_PIPELINE,
+        'partner_report_platform_name': TEST_PLATFORM_NAME,
         'org_partner_mapping': orgs,
         'drive_partners_folder': 'FakeDriveID'
     }

--- a/tubular/tests/test_retirement_partner_report.py
+++ b/tubular/tests/test_retirement_partner_report.py
@@ -27,7 +27,7 @@ from tubular.scripts.retirement_partner_report import (
     REPORTING_FILENAME_PREFIX,
     generate_report
 )
-from tubular.tests.retirement_helpers import fake_config_file, fake_google_secrets_file, FAKE_ORGS
+from tubular.tests.retirement_helpers import fake_config_file, fake_google_secrets_file, FAKE_ORGS, TEST_PLATFORM_NAME
 
 
 TEST_CONFIG_YML_NAME = 'test_config.yml'
@@ -83,8 +83,8 @@ def _call_script(expect_success=True, config_orgs=None):
             config_org_vals = [unicodedata.normalize('NFKC', org) for org in config_org_vals]
 
             for org in config_org_vals:
-                outfile = os.path.join(tmp_output_dir, '{}_{}_{}.csv'.format(
-                    REPORTING_FILENAME_PREFIX, org, date.today().isoformat()
+                outfile = os.path.join(tmp_output_dir, '{}_{}_{}_{}.csv'.format(
+                    REPORTING_FILENAME_PREFIX, TEST_PLATFORM_NAME, org, date.today().isoformat()
                 ))
 
                 with open(outfile, 'r') as csvfile:


### PR DESCRIPTION
The motivation is to be able to use the same exact google drive folders
for both prod and edge without a chance of filename collision.

PLAT-2235