### PR TITLE
Tag partners in Drive comment notifications

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ David Ormsbee <dave@edx.org>
 Dillon Dumesnil <ddumesnil@edx.org>
 Dillon Dumesnil <dillon.dumesnil@gmail.com>
 Dillon-Dumesnil <dillon.dumesnil@gmail.com>
+Douglas Hall <dhall@edx.org>
 Elton Carr, II <eltonc@microsoft.com>
 Feanil Patel <feanil@edx.org>
 Fred Smith <derf@edx.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,16 @@
 CHANGES
 =======
 
+* Tag partners in Drive comment notifications
+* Add missed script symlink to retirement\_bulk\_status\_update.py
+* Add user\_id to the report
+* Add deletion\_completed field to Partner Reporting
+* Refactor setup methods
+* Add retirement\_bulk\_status\_update script and support
+* Fix partner report filenames - remove absolute path
+* add the platform name to generated partner report files
+* Added scripts used when deploying frontend apps
+* Fix formatting of username results on report generation to fix queue deletion
 * Add script to delete expired partner reports
 * Correct test\_get\_pr\_in\_range mock for search\_issues
 * search github prs using string

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ edx-opaque-keys==0.4.0
 edx-rest-api-client==1.7.1
 enum34 >=1.1.6, <2.0; python_version < '3.4'
 freezegun==0.3.8
+future==0.16.0
 GitPython==2.1.8
 google-api-python-client==1.7.3
 jenkinsapi==0.3.3


### PR DESCRIPTION
At a high level:
* Implements a new DriveApi function list_permissions_for_files.
* Refactors create_comments_for_files to allow different comments per file.
* Updates the retirement_partner_report script to add tags to comments.
* Adds "future" to requerements, one small backstep for mankind.

PLAT-2265