### PR TITLE
Switch to unicodecsv for partner reporting

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
 CHANGES
 =======
 
+* Switch to unicodecsv for partner reporting
+* Fix parsing of cloudflare zone name from frontend bucket name
+* Check and log all mismatched orgs before reporting
 * Tag partners in Drive comment notifications
 * Add missed script symlink to retirement\_bulk\_status\_update.py
 * Add user\_id to the report
@@ -8,6 +11,7 @@ CHANGES
 * Refactor setup methods
 * Add retirement\_bulk\_status\_update script and support
 * Fix partner report filenames - remove absolute path
+* Purge CloudFlare cache when frontend app is deployed
 * add the platform name to generated partner report files
 * Added scripts used when deploying frontend apps
 * Fix formatting of username results on report generation to fix queue deletion

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ requests>=2.9.1,<3.0
 six
 validators
 yagocd==0.4.4
+unicodecsv==0.14.1

--- a/tubular/scripts/retirement_partner_report.py
+++ b/tubular/scripts/retirement_partner_report.py
@@ -9,11 +9,11 @@ from __future__ import absolute_import, unicode_literals
 from collections import defaultdict, OrderedDict
 from datetime import date
 from functools import partial
-import csv
 import logging
 import os
 import sys
 import unicodedata
+import unicodecsv as csv
 
 import click
 from six import text_type
@@ -145,7 +145,7 @@ def _generate_report_files_or_exit(config, report_data, output_dir):
             except OSError:
                 pass
 
-            with open(outfile, 'w') as f:
+            with open(outfile, 'wb') as f:
                 writer = csv.DictWriter(f, fields, dialect=csv.excel, extrasaction='ignore')
                 writer.writeheader()
                 writer.writerows(report_data[partner])

--- a/tubular/tests/test_retirement_partner_report.py
+++ b/tubular/tests/test_retirement_partner_report.py
@@ -387,7 +387,7 @@ def test_unknown_org(*args, **kwargs):
 @patch('tubular.google_api.DriveApi.__init__')
 @patch('tubular.google_api.DriveApi.walk_files')
 @patch('tubular.edx_api.BaseApiClient.get_access_token')
-@patch('csv.DictWriter')
+@patch('unicodecsv.DictWriter')
 @patch('tubular.edx_api.LmsApi.retirement_partner_report')
 def test_reporting_error(*args):
     mock_retirement_report = args[0]


### PR DESCRIPTION
This may prevent unicode errors on the jenkins job because it's "more
correct", but it's still a guess.

PLAT-2283