### PR TITLE
encode all strings going out to the console

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 CHANGES
 =======
 
+* encode all strings going out to the console
 * Switch to unicodecsv for partner reporting
 * Fix parsing of cloudflare zone name from frontend bucket name
 * Check and log all mismatched orgs before reporting

--- a/tubular/scripts/helpers.py
+++ b/tubular/scripts/helpers.py
@@ -1,6 +1,14 @@
 """
 Common helper methods to use in tubular scripts.
 """
+# NOTE: Make sure that all non-ascii text written to standard output (including
+# print statements and logging) is manually encoded to bytes using a utf-8 or
+# other encoding.  We currently make use of this library within a context that
+# does NOT tolerate unicode text on sys.stdout, namely python 2 on Build
+# Jenkins.  PLAT-2287 tracks this Tech Debt.
+
+from __future__ import print_function
+
 import io
 import json
 import sys
@@ -8,7 +16,6 @@ import traceback
 import unicodedata
 from os import path
 
-import click
 import yaml
 from six import text_type
 
@@ -22,7 +29,7 @@ def _log(kind, message):
     """
     Convenience method to log text. Prepended "kind" text makes finding log entries easier.
     """
-    click.echo('{}: {}'.format(kind, message))
+    print(u'{}: {}'.format(kind, message).encode('utf-8'))  # See note at the top of this file.
 
 
 def _fail(kind, code, message):

--- a/tubular/scripts/retirement_partner_report.py
+++ b/tubular/scripts/retirement_partner_report.py
@@ -4,6 +4,12 @@
 """
 Command-line script to drive the partner reporting part of the retirement process
 """
+# NOTE: Make sure that all non-ascii text written to standard output (including
+# print statements and logging) is manually encoded to bytes using a utf-8 or
+# other encoding.  We currently make use of this script within a context that
+# does NOT tolerate unicode text on sys.stdout, namely python 2 on Build
+# Jenkins.  PLAT-2287 tracks this Tech Debt.
+
 from __future__ import absolute_import, unicode_literals
 
 from collections import defaultdict, OrderedDict


### PR DESCRIPTION
This prevents UnicodeEncode errors on Build Jenkins by encoding all text before being written to `sys.stdout`.  This workaround is essentially a spot treatment because we only run some scripts under these limitations (python 2 on build jenkins).  Other related retirement scripts were not changed because they either only import from `tubular/scripts/helpers.py` which contains the workaround, or they aren't expected to print non-ascii characters.