### PR TITLE
Add script to delete Google Drive files by ID.

### DIFF
--- a/scripts/delete_drive_files.py
+++ b/scripts/delete_drive_files.py
@@ -1,0 +1,1 @@
+../tubular/scripts/delete_drive_files.py

--- a/tubular/scripts/delete_drive_files.py
+++ b/tubular/scripts/delete_drive_files.py
@@ -1,0 +1,97 @@
+#! /usr/bin/env python3
+"""
+Command-line script to delete Google Drive files by ID.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from functools import partial
+from os import path
+import logging
+import sys
+
+import click
+
+# Add top-level module path to sys.path before importing tubular code.
+sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+
+from tubular.google_api import DriveApi  # pylint: disable=wrong-import-position
+# pylint: disable=wrong-import-position
+from tubular.scripts.helpers import (
+    _config_with_drive_or_exit,
+    _fail,
+    _fail_exception,
+    _log
+)
+
+# The Google API cannot delete more than this number of file IDs at once.
+MAX_FILE_IDS = 100
+
+# Return codes for various fail cases
+ERR_NO_CONFIG = -1
+ERR_BAD_CONFIG = -2
+ERR_NO_SECRETS = -3
+ERR_BAD_SECRETS = -4
+ERR_DELETING_FILES = -5
+ERR_NO_FILE_IDS = -6
+ERR_TOO_MANY_FILE_IDS = -7
+
+SCRIPT_SHORTNAME = 'delete_drive_files'
+LOG = partial(_log, SCRIPT_SHORTNAME)
+FAIL = partial(_fail, SCRIPT_SHORTNAME)
+FAIL_EXCEPTION = partial(_fail_exception, SCRIPT_SHORTNAME)
+CONFIG_WITH_DRIVE_OR_EXIT = partial(_config_with_drive_or_exit, FAIL_EXCEPTION, ERR_BAD_CONFIG, ERR_BAD_SECRETS)
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
+
+@click.command()
+@click.option(
+    '--config_file',
+    help='YAML file that contains retirement-related configuration for this environment.'
+)
+@click.option(
+    '--google_secrets_file',
+    help='JSON file with Google service account credentials for deletion purposes.'
+)
+@click.option(
+    '--file_id',
+    multiple=True,
+    help='File ID(s) of Google Drive file(s) to delete.'
+)
+def delete_files(config_file, google_secrets_file, file_id):
+    """
+    Deletes the specified Google Drive files by ID.
+    """
+    LOG('Starting Drive file deletion using config file "{}" and Google config "{}"'.format(
+        config_file, google_secrets_file
+    ))
+
+    # The file_id option collects *all* file_id options from the command-line.
+    # So there's likely multiple file IDs to process. Rename this option for clarity.
+    file_ids = file_id
+
+    if not config_file:
+        FAIL(ERR_NO_CONFIG, 'No config file passed in.')
+
+    if not google_secrets_file:
+        FAIL(ERR_NO_SECRETS, 'No secrets file passed in.')
+
+    if not file_ids:
+        FAIL(ERR_NO_FILE_IDS, 'No file IDs were specified.')
+
+    if len(file_ids) > MAX_FILE_IDS:
+        FAIL(ERR_TOO_MANY_FILE_IDS, "Too many file IDs specfied: {}. Maximum is {}".format(len(file_ids), MAX_FILE_IDS))
+
+    config = CONFIG_WITH_DRIVE_OR_EXIT(config_file, google_secrets_file)
+
+    try:
+        drive = DriveApi(config['google_secrets_file'])
+        drive.delete_files(file_ids)
+        LOG('All files deleted successfully.')
+    except Exception as exc:  # pylint: disable=broad-except
+        FAIL_EXCEPTION(ERR_DELETING_FILES, 'Unexpected error occurred!', exc)
+
+
+if __name__ == '__main__':
+    # pylint: disable=unexpected-keyword-arg, no-value-for-parameter
+    delete_files(auto_envvar_prefix='RETIREMENT')

--- a/tubular/scripts/helpers.py
+++ b/tubular/scripts/helpers.py
@@ -81,7 +81,7 @@ def _config_with_drive_or_exit(fail_func, config_fail_code, google_fail_code, co
         # Check required values
         for var in ('org_partner_mapping', 'drive_partners_folder'):
             if var not in config or not config[var]:
-                fail_func(config_fail_code, 'No {} in config, or it is empty!'.format(var))
+                fail_func(config_fail_code, 'No {} in config, or it is empty!'.format(var), ValueError())
 
         # Force the partner names into NFKC here and when we get the folders to ensure
         # they are using the same characters. Otherwise accented characters will not match.

--- a/tubular/tests/test_delete_drive_files.py
+++ b/tubular/tests/test_delete_drive_files.py
@@ -1,0 +1,171 @@
+# coding=utf-8
+"""
+Test the retire_one_learner.py script
+"""
+from __future__ import print_function
+
+from click.testing import CliRunner
+from mock import patch
+
+from tubular.scripts.delete_drive_files import (
+    ERR_NO_CONFIG,
+    ERR_BAD_CONFIG,
+    ERR_NO_SECRETS,
+    ERR_BAD_SECRETS,
+    ERR_DELETING_FILES,
+    ERR_NO_FILE_IDS,
+    ERR_TOO_MANY_FILE_IDS,
+    delete_files
+)
+from tubular.tests.retirement_helpers import fake_config_file, fake_google_secrets_file, FAKE_ORGS
+
+
+TEST_CONFIG_YML_NAME = 'test_config.yml'
+TEST_GOOGLE_SECRETS_FILENAME = 'test_google_secrets.json'
+
+
+def _call_script(expect_success=True, config_orgs=None, file_ids=None):
+    """
+    Call the retired learner script with generic, temporary config files and specified file IDs.
+    Returns the CliRunner.invoke results.
+    """
+    if config_orgs is None:
+        config_orgs = FAKE_ORGS
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open(TEST_CONFIG_YML_NAME, 'w') as config_f:
+            fake_config_file(config_f, config_orgs)
+        with open(TEST_GOOGLE_SECRETS_FILENAME, 'w') as secrets_f:
+            fake_google_secrets_file(secrets_f)
+
+        cmd_args = [
+            '--config_file',
+            TEST_CONFIG_YML_NAME,
+            '--google_secrets_file',
+            TEST_GOOGLE_SECRETS_FILENAME,
+        ]
+        if file_ids:
+            for file_id in file_ids:
+                cmd_args.extend(['--file_id', file_id])
+
+        result = runner.invoke(
+            delete_files,
+            args=cmd_args
+        )
+
+        print(result)
+        print(result.output)
+
+        if expect_success:
+            assert result.exit_code == 0
+
+    return result
+
+
+@patch('tubular.google_api.DriveApi.__init__')
+@patch('tubular.google_api.DriveApi.delete_files')
+def test_successful_report(*args):
+    mock_delete_files = args[0]
+    mock_driveapi = args[1]
+
+    mock_delete_files.return_value = None
+    mock_driveapi.return_value = None
+
+    result = _call_script(file_ids=['fake_file_id1', 'fake_file_id2'])
+
+    # Make sure we tried to delete the files
+    assert mock_delete_files.call_count == 1
+
+    assert 'All files deleted successfully.' in result.output
+
+
+@patch('tubular.google_api.DriveApi.__init__')
+def test_unknown_error(*args):
+    mock_driveapi = args[0]
+    mock_driveapi.side_effect = Exception('Unknown error.')
+
+    result = _call_script(expect_success=False, file_ids=['fake_file_id1'])
+    print(result.output)
+    assert result.exit_code == ERR_DELETING_FILES
+    assert 'Unexpected error occurred' in result.output
+
+
+def test_no_file_ids():
+    result = _call_script(expect_success=False)
+    print(result.output)
+    assert result.exit_code == ERR_NO_FILE_IDS
+    assert 'No file IDs were specified' in result.output
+
+
+def test_too_many_file_ids():
+    result = _call_script(expect_success=False, file_ids=['fake_file_id{}'.format(i) for i in range(150)])
+    print(result.output)
+    assert result.exit_code == ERR_TOO_MANY_FILE_IDS
+    assert 'Too many file IDs specfied' in result.output
+
+
+def test_no_config():
+    runner = CliRunner()
+    result = runner.invoke(delete_files)
+    print(result.output)
+    assert result.exit_code == ERR_NO_CONFIG
+    assert 'No config file' in result.output
+
+
+def test_no_secrets():
+    runner = CliRunner()
+    result = runner.invoke(delete_files, args=['--config_file', 'does_not_exist.yml'])
+    print(result.output)
+    assert result.exit_code == ERR_NO_SECRETS
+    assert 'No secrets file' in result.output
+
+
+def test_bad_config():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open(TEST_CONFIG_YML_NAME, 'w') as config_f:
+            config_f.write(']this is bad yaml')
+
+        with open(TEST_GOOGLE_SECRETS_FILENAME, 'w') as config_f:
+            config_f.write('{this is bad json but we should not get to parsing it')
+
+        result = runner.invoke(
+            delete_files,
+            args=[
+                '--config_file',
+                TEST_CONFIG_YML_NAME,
+                '--google_secrets_file',
+                TEST_GOOGLE_SECRETS_FILENAME,
+                '--file_id',
+                'a_fake_file_id'
+            ]
+        )
+        print(result.output)
+        assert result.exit_code == ERR_BAD_CONFIG
+        assert 'Failed to read' in result.output
+
+
+def test_bad_secrets():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open(TEST_CONFIG_YML_NAME, 'w') as config_f:
+            fake_config_file(config_f)
+
+        with open(TEST_GOOGLE_SECRETS_FILENAME, 'w') as config_f:
+            config_f.write('{this is bad json')
+
+        result = runner.invoke(
+            delete_files,
+            args=[
+                '--config_file',
+                TEST_CONFIG_YML_NAME,
+                '--google_secrets_file',
+                TEST_GOOGLE_SECRETS_FILENAME,
+                '--file_id',
+                'a_fake_file_id'
+            ]
+        )
+        print(result.output)
+        assert result.exit_code == ERR_BAD_SECRETS
+        assert 'Failed to read' in result.output


### PR DESCRIPTION
This script was a by-product of needing to delete duplicate partner reports from Google Drive today. I scraped the file IDs for the script from the Jenkins log:

https://build.testeng.edx.org/job/retirement-partner-reporter/27/consoleText

by using this shell incantation:
```
grep "INFO:tubular.google_api:File uploaded:" ../../reports_to_delete1.txt | awk '{split($0, a, "\""); printf "--file_id %s ", a[2]}'
```
and pasting it onto the end of the following command:
```
python scripts/delete_drive_files.py --config_file prod-edx.yml --google_secrets_file service-account-prod-edx.json
```
like this:
```
python scripts/delete_drive_files.py --config_file prod-edx.yml --google_secrets_file service-account-prod-edx.json --file_id file_id1 --file_id file_id2
```