### PR TITLE
Perform Google API retries correctly

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ CHANGES
 =======
 
 * Fail when listing partner folders retuns zero results
+* Perform Google API retries correctly
 * encode all strings going out to the console
 * Switch to unicodecsv for partner reporting
 * Fix parsing of cloudflare zone name from frontend bucket name


### PR DESCRIPTION
Primarily, this new iteration of the code does not assume that
rate limiting can only happen at the HTTP level, but in fact it may
happen additionally at the logical request level.

Also, this adds chunking to the delete_files() method using this same
retry framework.

PLAT-2286