### PR TITLE
add crumb requester to jenkins

### DIFF
--- a/tubular/jenkins.py
+++ b/tubular/jenkins.py
@@ -11,6 +11,7 @@ import shutil
 
 import backoff
 from jenkinsapi.jenkins import Jenkins
+from jenkinsapi.utils.crumb_requester import CrumbRequester
 from jenkinsapi.custom_exceptions import JenkinsAPIException
 from requests.exceptions import HTTPError
 
@@ -159,7 +160,14 @@ def trigger_build(base_url, user_name, user_token, job_name, job_token,
 
     # Contact jenkins, log in, and get the base data on the system.
     try:
-        jenkins = Jenkins(base_url, username=user_name, password=user_token)
+        crumb_requester = CrumbRequester(
+            baseurl=base_url, username=user_name, password=user_token,
+            ssl_verify=True
+        )
+        jenkins = Jenkins(
+            base_url, username=user_name, password=user_token,
+            requester=crumb_requester
+        )
     except (JenkinsAPIException, HTTPError) as err:
         raise BackendError(str(err))
 

--- a/tubular/tests/test_jenkins.py
+++ b/tubular/tests/test_jenkins.py
@@ -49,6 +49,10 @@ MOCK_BUILD_DATA = {
     'result': 'SUCCESS',
     'url': JOB_URL,
 }
+MOCK_CRUMB_DATA = {
+    'crumbRequestField': 'Jenkins-Crumb',
+    'crumb': '1234567890'
+}
 
 
 class TestProperties(unittest.TestCase):
@@ -164,6 +168,8 @@ class TestJenkinsAPI(unittest.TestCase):
                 return json.dumps(MOCK_BUILDS_DATA)
             elif request.url.startswith(u'https://test-jenkins/queue/item/123/api/python'):
                 return json.dumps(MOCK_QUEUE_DATA)
+            elif request.url.startswith(u'https://test-jenkins/crumbIssuer/api/python'):
+                return json.dumps(MOCK_CRUMB_DATA)
             else:
                 # We should never get here, unless the jenkinsapi implementation changes.
                 # This response will catch that condition.


### PR DESCRIPTION
This will allow us to access the Jenkins API with crumbs, part of the CSRF protection mechanism. For more info, see:
* https://github.com/edx/jenkins-configuration/pull/103
* https://github.com/edx/configuration/pull/4746