### PR TITLE
Revert "Renamed confluence release status keys to match github api and gomatic"

### DIFF
--- a/tubular/confluence_api.py
+++ b/tubular/confluence_api.py
@@ -57,9 +57,9 @@ LOGGER = logging.getLogger(__name__)
 
 class ReleaseStatus(Enum):
     u"""The set of valid release states."""
-    stage = u"Deployed to Staging"
-    prod = u"Deployed to Production"
-    prod_rollback = u"Rolled back from Production"
+    STAGED = u"Deployed to Staging"
+    DEPLOYED = u"Deployed to Production"
+    ROLLED_BACK = u"Rolled back from Production"
 
 
 class AMI(object):

--- a/tubular/tests/test_confluence_api.py
+++ b/tubular/tests/test_confluence_api.py
@@ -44,7 +44,7 @@ def test_release_page(mock_github):
     page = ReleasePage(
         u'github_token',
         u'jira_url',
-        ReleaseStatus.prod,
+        ReleaseStatus.DEPLOYED,
         [
             (
                 AMI(


### PR DESCRIPTION
Reverts edx/tubular#274