### PR TITLE
Update retirement to fetch Segment Ecom ID into config when configured

### DIFF
--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -306,6 +306,16 @@ class EcommerceApi(BaseApiClient):
         with correct_exception():
             return self._client.api.v2.user.retire.post(**params)
 
+    @_retry_lms_api()
+    def get_tracking_key(self, learner):
+        """
+        Fetches the ecommerce tracking id used for Segment tracking when
+        ecommerce doesn't have access to the LMS user id.
+        """
+        with correct_exception():
+            result = self._client.api.v2.retirement.tracking_id(learner['original_username']).get()
+            return result['ecommerce_tracking_id']
+
 
 class CredentialsApi(BaseApiClient):
     """

--- a/tubular/scripts/retire_one_learner.py
+++ b/tubular/scripts/retire_one_learner.py
@@ -129,6 +129,21 @@ def _get_learner_and_state_index_or_exit(config, username):
         FAIL_EXCEPTION(ERR_SETUP_FAILED, 'Unexpected error fetching user state!', text_type(exc))
 
 
+def _get_ecom_segment_id(config, learner):
+    """
+    Calls Ecommerce to get the ecom-specific Segment tracking id that we need to retire.
+    This is only available from Ecommerce, unfortunately, and makes more sense to handle
+    here than to pass all of the config down to SegmentApi.
+    """
+    try:
+        return config['ECOMMERCE'].get_tracking_key(learner)
+    except HttpNotFoundError:
+        LOG('Learner {} not found in Ecommerce. Setting Ecommerce Segment ID to None'.format(learner))
+        return None
+    except Exception as exc:  # pylint: disable=broad-except
+        FAIL_EXCEPTION(ERR_SETUP_FAILED, 'Unexpected error fetching Ecommerce tracking id!', text_type(exc))
+
+
 @click.command()
 @click.option(
     '--username',
@@ -156,6 +171,9 @@ def retire_learner(
     SETUP_ALL_APIS_OR_EXIT(config)
 
     learner, learner_state_index = _get_learner_and_state_index_or_exit(config, username)
+
+    if config.get('fetch_ecommerce_segment_id', False):
+        learner['ecommerce_segment_id'] = _get_ecom_segment_id(config, learner)
 
     start_state = None
     try:

--- a/tubular/segment_api.py
+++ b/tubular/segment_api.py
@@ -9,7 +9,7 @@ from six import text_type
 
 
 # These are the keys in the learner dict that contain IDs we need to retire from Segment
-IDENTIFYING_KEYS = ['id', 'original_username', 'ecommerce_id']
+IDENTIFYING_KEYS = ['id', 'original_username', 'ecommerce_segment_id']
 
 # The Segment GraphQL mutation for authorization
 AUTH_MUTATION = "mutation auth($email:String!, $password:String!) {login(email:$email, password:$password)}"

--- a/tubular/tests/retirement_helpers.py
+++ b/tubular/tests/retirement_helpers.py
@@ -34,7 +34,7 @@ TEST_BLACKLISTED_NOTIFICATION_DOMAINS = {
 }
 
 
-def fake_config_file(f, orgs=None):
+def fake_config_file(f, orgs=None, fetch_ecom_segment_id=False):
     """
     Create a config file for a single test. Combined with CliRunner.isolated_filesystem() to
     ensure the file lifetime is limited to the test. See _call_script for usage.
@@ -56,6 +56,9 @@ def fake_config_file(f, orgs=None):
         'drive_partners_folder': 'FakeDriveID',
         'blacklisted_notification_domains': TEST_BLACKLISTED_NOTIFICATION_DOMAINS,
     }
+
+    if fetch_ecom_segment_id:
+        config['fetch_ecommerce_segment_id'] = True
 
     yaml.safe_dump(config, f)
 

--- a/tubular/tests/test_segment_api.py
+++ b/tubular/tests/test_segment_api.py
@@ -30,7 +30,7 @@ def test_suppress_and_delete_success():
     Test simple success case
     """
     projects_to_retire = ['project_1', 'project_2']
-    learner = {'id': 1, 'ecommerce_id': 'ecommerce-20', 'original_username': 'test_user'}
+    learner = {'id': 1, 'ecommerce_segment_id': 'ecommerce-20', 'original_username': 'test_user'}
     fake_base_url = 'https://segment.invalid'
     fake_email = 'fake_email'
     fake_password = 'fake_password'


### PR DESCRIPTION
This is a retry of https://github.com/edx/tubular/pull/279 which was reverted due to failing tests on master. The only differences are new mocks on the tests that were failing and making this call explicitly configurable for better open source compatibility / reduced chances of new tests accidentally not mocking this call.