### PR TITLE
Remove possibility of AttributeError exception to avoid stomping.

### DIFF
--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -130,9 +130,9 @@ def correct_exception():
         else:
             raise err
     except HttpClientError as err:
-        try:
+        if hasattr(err, 'content'):
             LOG.error("API Error: {}".format(err.content))
-        except AttributeError:
+        else:
             LOG.error("API Error: {}".format(text_type(err)))
         raise err
 

--- a/tubular/scripts/retire_one_learner.py
+++ b/tubular/scripts/retire_one_learner.py
@@ -209,12 +209,10 @@ def retire_learner(
     except Exception as exc:  # pylint: disable=broad-except
         exc_msg = text_type(exc)
 
-        try:
+        if hasattr(exc, 'content'):
             # Slumber inconveniently discards the decoded .text attribute from the Response object, and instead gives us
             # the raw encoded .content attribute, so we need to decode it first.
             exc_msg += '\n' + exc.content.decode('utf-8')
-        except AttributeError:
-            pass
 
         try:
             LOG('Error in retirement state {}: {}'.format(start_state, exc_msg))

--- a/tubular/tests/test_google_api.py
+++ b/tubular/tests/test_google_api.py
@@ -32,6 +32,7 @@ class TestDriveApi(unittest.TestCase):
     maxDiff = None
 
     def setUp(self):
+        super(TestDriveApi, self).setUp()
         with open(DISCOVERY_DRIVE_RESPONSE_FILE, 'r') as f:
             self.mock_discovery_response_content = f.read()
 
@@ -518,7 +519,7 @@ ETag: "etag/sheep"\r\n\r\n{"id": "fake-comment-id1"}
         mechanism when a subset of responses are rate limited.
         """
         num_files = int(GOOGLE_API_MAX_BATCH_SIZE * 1.5)
-        fake_file_ids = ['fake-file-id{}'.format(n) for n in range(0, num_files)]
+        fake_file_ids = ['fake-file-id{}'.format(n) for n in range(num_files)]
         batch_response_0 = '\n'.join(
             '''--batch_foobarbaz
 Content-Type: application/http
@@ -528,7 +529,7 @@ Content-ID: <response+{idx}>
 HTTP/1.1 204 OK
 ETag: "etag/pony{idx}"\r\n\r\n{{"id": "fake-comment-id{idx}"}}
 '''.format(idx=n)
-            for n in range(0, GOOGLE_API_MAX_BATCH_SIZE)
+            for n in range(GOOGLE_API_MAX_BATCH_SIZE)
         )
         batch_response_0 += '--batch_foobarbaz--'
         batch_response_1 = '\n'.join(
@@ -540,7 +541,7 @@ Content-ID: <response+{idx}>
 HTTP/1.1 204 OK
 ETag: "etag/pony{idx}"\r\n\r\n{{"id": "fake-comment-id{idx}"}}
 '''.format(idx=n)
-            for n in range(0, int(GOOGLE_API_MAX_BATCH_SIZE * 0.25))
+            for n in range(int(GOOGLE_API_MAX_BATCH_SIZE * 0.25))
         )
         batch_response_1 += '\n'
         batch_response_1 += '\n'.join(
@@ -586,7 +587,7 @@ ETag: "etag/pony{idx}"\r\n\r\n{{"id": "fake-comment-id{idx}"}}
             resp,
             {
                 'fake-file-id{}'.format(n): {'id': 'fake-comment-id{}'.format(n)}
-                for n in range(0, num_files)
+                for n in range(num_files)
             },
         )
 

--- a/tubular/tests/test_jenkins.py
+++ b/tubular/tests/test_jenkins.py
@@ -73,11 +73,11 @@ class TestProperties(unittest.TestCase):
             jenkins._recreate_directory = Mock()  # pylint: disable=protected-access
             jenkins.export_learner_job_properties(learners, "tmpdir")
         jenkins._recreate_directory.assert_called_once()  # pylint: disable=protected-access
-        self.assertTrue(call('tmpdir/learner_retire_learnera', 'w') in open_mocker.call_args_list)
-        self.assertTrue(call('tmpdir/learner_retire_learnerb', 'w') in open_mocker.call_args_list)
+        self.assertIn(call('tmpdir/learner_retire_learnera', 'w'), open_mocker.call_args_list)
+        self.assertIn(call('tmpdir/learner_retire_learnerb', 'w'), open_mocker.call_args_list)
         handle = open_mocker()
-        self.assertTrue(call('RETIREMENT_USERNAME=learnerA\n') in handle.write.call_args_list)
-        self.assertTrue(call('RETIREMENT_USERNAME=learnerB\n') in handle.write.call_args_list)
+        self.assertIn(call('RETIREMENT_USERNAME=learnerA\n'), handle.write.call_args_list)
+        self.assertIn(call('RETIREMENT_USERNAME=learnerB\n'), handle.write.call_args_list)
 
 
 @ddt.ddt


### PR DESCRIPTION
Avoid exception stomping in retire_one_learner.py by checking explicitly for the `content` attribute instead of trying to access it and raising an AttributeError. Avoids this type of misleading log:
```
16:10:46 Learner Retirement: Starting state RETIRING_EMAIL_LISTS
16:10:46 ERROR:tubular.sailthru_api:Error attempting to delete user a_random_user@gmail.com from Sailthru - User not found with email: a_random_user@gmail.com
16:10:46 Learner Retirement: Error in retirement state RETIRING_EMAIL_LISTS: Error attempting to delete user a_random_user@gmail.com from Sailthru - User not found with email: a_random_user@gmail.com
16:10:46 Learner Retirement: Error encountered in state "RETIRING_EMAIL_LISTS"
16:10:46 Error attempting to delete user a_random_user@gmail.com from Sailthru - User not found with email: a_random_user@gmail.com
16:10:46 Learner Retirement: Traceback (most recent call last):
16:10:46   File "scripts/retire_one_learner.py", line 215, in retire_learner
16:10:46     exc_msg += '\n' + exc.content.decode('utf-8')
16:10:46 AttributeError: 'exceptions.Exception' object has no attribute 'content'
```