### PR TITLE
sailthru deletion: swallow "not found" errors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 CHANGES
 =======
 
+* sailthru deletion: swallow "not found" errors
+* Fix pylint errors caused by new version
+* Avoid raising exception that stomps the important one
+* Segment API key fix and handling of missing projects
 * Add retirement archive and cleanup script
 * Add SailthruApi class and configure it in script helpers
 * fix changes

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ test =
     mock==2.0.0
     pep8==1.7.0
     pylint==1.7.1
-    pytest==3.1.3
+    pytest==3.6.3
     pytest-xdist==1.20.0
     pytest-pylint==0.9.0
     pytest-pep8

--- a/tubular/sailthru_api.py
+++ b/tubular/sailthru_api.py
@@ -33,8 +33,8 @@ class SailthruApi(object):
         try:
             sailthru_response = self._sailthru_client.api_delete("user", {'id': email})
         except SailthruClientError as exc:
-            error_msg = u"Exception attempting to delete user {} from Sailthru - {}".format(
-                email, text_type(exc)
+            error_msg = u"Exception attempting to delete user from Sailthru - {}".format(
+                text_type(exc)
             ).encode('utf-8')
             log.error(error_msg)
             raise Exception(error_msg)
@@ -42,15 +42,12 @@ class SailthruApi(object):
         if not sailthru_response.is_ok():
             error = sailthru_response.get_error()
             if SAILTHRU_ERROR_NOT_FOUND in error.get_message():
-                skip_msg = u"No action taken because no profile was found - {}".format(
-                    error.get_message()
-                ).encode('utf-8')
-                log.info(skip_msg)
+                log.info("No action taken because no user was found in Sailthru.")
             else:
-                error_msg = u"Error attempting to delete user {} from Sailthru - {}".format(
-                    email, error.get_message()
+                error_msg = u"Error attempting to delete user from Sailthru - {}".format(
+                    error.get_message()
                 ).encode('utf-8')
                 log.error(error_msg)
                 raise Exception(error_msg)
 
-        log.info("Email address %s successfully deleted from Sailthru.", email)
+        log.info("User successfully deleted from Sailthru.")

--- a/tubular/sailthru_api.py
+++ b/tubular/sailthru_api.py
@@ -9,6 +9,8 @@ from sailthru.sailthru_error import SailthruClientError
 
 log = logging.getLogger(__name__)
 
+SAILTHRU_ERROR_NOT_FOUND = 'User not found with email:'
+
 
 class SailthruApi(object):
     """
@@ -39,10 +41,16 @@ class SailthruApi(object):
 
         if not sailthru_response.is_ok():
             error = sailthru_response.get_error()
-            error_msg = u"Error attempting to delete user {} from Sailthru - {}".format(
-                email, error.get_message()
-            ).encode('utf-8')
-            log.error(error_msg)
-            raise Exception(error_msg)
+            if SAILTHRU_ERROR_NOT_FOUND in error.get_message():
+                skip_msg = u"No action taken because no profile was found - {}".format(
+                    error.get_message()
+                ).encode('utf-8')
+                log.info(skip_msg)
+            else:
+                error_msg = u"Error attempting to delete user {} from Sailthru - {}".format(
+                    email, error.get_message()
+                ).encode('utf-8')
+                log.error(error_msg)
+                raise Exception(error_msg)
 
         log.info("Email address %s successfully deleted from Sailthru.", email)

--- a/tubular/tests/test_sailthru.py
+++ b/tubular/tests/test_sailthru.py
@@ -27,7 +27,7 @@ def test_sailthru_delete_client_error(test_learner):  # pylint: disable=redefine
         sailthru_api._sailthru_client.api_delete.side_effect = SailthruClientError()  # pylint: disable=protected-access
         with pytest.raises(Exception) as exc:
             sailthru_api.delete_user(test_learner)
-        assert 'Exception attempting to delete user foo@bar.com from Sailthru' in str(exc)
+        assert 'Exception attempting to delete user from Sailthru' in str(exc)
 
 
 def test_sailthru_delete_not_ok_response(test_learner):  # pylint: disable=redefined-outer-name
@@ -41,7 +41,7 @@ def test_sailthru_delete_not_ok_response(test_learner):  # pylint: disable=redef
         sailthru_api._sailthru_client.api_delete.return_value = mock_response  # pylint: disable=protected-access
         with pytest.raises(Exception) as exc:
             sailthru_api.delete_user(test_learner)
-        assert 'Error attempting to delete user foo@bar.com from Sailthru' in str(exc)
+        assert 'Error attempting to delete user from Sailthru' in str(exc)
 
 
 def test_sailthru_delete_not_found_response(test_learner, caplog):  # pylint: disable=redefined-outer-name
@@ -60,15 +60,15 @@ def test_sailthru_delete_not_found_response(test_learner, caplog):  # pylint: di
         sailthru_api._sailthru_client.api_delete.return_value = mock_response  # pylint: disable=protected-access
         with caplog.at_level(logging.INFO):
             sailthru_api.delete_user(test_learner)
-        assert 'No action taken because no profile was found - User not found with email: foo@bar.com' in caplog.text
+        assert 'No action taken because no user was found in Sailthru.' in caplog.text
 
 
-@mock.patch('tubular.sailthru_api.log')
-def test_sailthru_success(mock_logger, test_learner):  # pylint: disable=redefined-outer-name
+def test_sailthru_success(test_learner, caplog):  # pylint: disable=redefined-outer-name
     with mock.patch('tubular.sailthru_api.SailthruClient'):
         sailthru_api = SailthruApi('key', 'secret')
         mock_response = mock.Mock()
         mock_response.is_ok.return_value = True
         sailthru_api._sailthru_client.api_delete.return_value = mock_response  # pylint: disable=protected-access
-        sailthru_api.delete_user(test_learner)
-        mock_logger.info.assert_called_with('Email address %s successfully deleted from Sailthru.', 'foo@bar.com')
+        with caplog.at_level(logging.INFO):
+            sailthru_api.delete_user(test_learner)
+        assert 'User successfully deleted from Sailthru.' in caplog.text

--- a/tubular/tests/test_sailthru.py
+++ b/tubular/tests/test_sailthru.py
@@ -1,6 +1,7 @@
 """
 Tests for the Sailthru API functionality
 """
+import logging
 import mock
 import pytest
 
@@ -34,10 +35,32 @@ def test_sailthru_delete_not_ok_response(test_learner):  # pylint: disable=redef
         sailthru_api = SailthruApi('key', 'secret')
         mock_response = mock.Mock()
         mock_response.is_ok.return_value = False
+        mock_error = mock.Mock()
+        mock_error.get_message.return_value = "Random error message, doesnt matter what this is."
+        mock_response.get_error.return_value = mock_error
         sailthru_api._sailthru_client.api_delete.return_value = mock_response  # pylint: disable=protected-access
         with pytest.raises(Exception) as exc:
             sailthru_api.delete_user(test_learner)
         assert 'Error attempting to delete user foo@bar.com from Sailthru' in str(exc)
+
+
+def test_sailthru_delete_not_found_response(test_learner, caplog):  # pylint: disable=redefined-outer-name
+    """
+    The user never opted into email marketing, so they never had a sailthru
+    profile generated.  Sailthru will respond with a "not found" error, which
+    we should treat as "no action needed".
+    """
+    with mock.patch('tubular.sailthru_api.SailthruClient'):
+        sailthru_api = SailthruApi('key', 'secret')
+        mock_response = mock.Mock()
+        mock_response.is_ok.return_value = False
+        mock_error = mock.Mock()
+        mock_error.get_message.return_value = 'User not found with email: foo@bar.com'
+        mock_response.get_error.return_value = mock_error
+        sailthru_api._sailthru_client.api_delete.return_value = mock_response  # pylint: disable=protected-access
+        with caplog.at_level(logging.INFO):
+            sailthru_api.delete_user(test_learner)
+        assert 'No action taken because no profile was found - User not found with email: foo@bar.com' in caplog.text
 
 
 @mock.patch('tubular.sailthru_api.log')


### PR DESCRIPTION
We should not assume that every user on the platform has a corresponding
sailthru profile, especially now that we correctly respect email opt-in
checkboxes everywhere.