### PR TITLE
Change retirement archive to use the Jenkins AWS assumed role

### DIFF
--- a/tubular/scripts/retirement_archive_and_cleanup.py
+++ b/tubular/scripts/retirement_archive_and_cleanup.py
@@ -106,17 +106,7 @@ def _upload_to_s3(config, filename, dry_run=False):
     Upload the archive file to S3
     """
     try:
-        s3_credentials = ()
-        if 'access_key' in config['s3_archive']:
-            s3_credentials = (
-                config['s3_archive']['access_key'],
-                config['s3_archive']['secret_key'],
-            )
-
-        s3_connection = S3Connection(
-            *s3_credentials,
-            host='s3.{}.amazonaws.com'.format(config['s3_archive']['region'])
-        )
+        s3_connection = S3Connection()
 
         datestr = datetime.datetime.now().strftime('%Y/%m/')
 


### PR DESCRIPTION
This PR switched the script from using an access key to an assumed role.