### PR TITLE
Fix to avoid TypeError

### DIFF
--- a/tubular/scripts/structures.py
+++ b/tubular/scripts/structures.py
@@ -62,6 +62,9 @@ def cli(ctx, connection, database_name):
     handles courses that use the old "/" separator, such as
     "MITx/6.002x/2012_Spring", as well as assets starting with "i4x://".
     """
+    if ctx.obj is None:
+        ctx.obj = dict()
+
     ctx.obj['BACKEND'] = SplitMongoBackend(connection, database_name)
 
 


### PR DESCRIPTION
I am trying to use the structures.py command of tubular. I am using virtualenv with python3 and installing this repo.

When I run:
`structures.py --connection="mongodb://user:password@mongo_ip/edxapp" --database-name edxapp make_plan -v DEBUG out.json --details details.txt --retain 20`

It fails with this output:

~~~~Traceback (most recent call last):
  File "/edx/src/venv/bin/structures.py", line 11, in <module>
    sys.exit(cli())
  File "/edx/src/venv/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/edx/src/venv/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/edx/src/venv/lib/python3.5/site-packages/click/core.py", line 1063, in invoke
    Command.invoke(self, ctx)
  File "/edx/src/venv/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/edx/src/venv/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/edx/src/venv/lib/python3.5/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/edx/src/venv/lib/python3.5/site-packages/tubular/scripts/structures.py", line 67, in cli
    ctx.obj['BACKEND'] = SplitMongoBackend(connection, database_name)
TypeError: 'NoneType' object does not support item assignment
~~~~

With the changes of this PR, the command doesn't fail

Is this the proper way to run this module?