### PR TITLE
Segment: Add query all single-user deletes. Remove projects.

### DIFF
--- a/scripts/query_all_segment_deletion_requests.py
+++ b/scripts/query_all_segment_deletion_requests.py
@@ -1,0 +1,1 @@
+../tubular/scripts/query_all_segment_deletion_requests.py

--- a/tubular/scripts/bulk_delete_segment_users.py
+++ b/tubular/scripts/bulk_delete_segment_users.py
@@ -79,10 +79,9 @@ def bulk_delete_segment_users(dry_run, config_file, retired_users_csv, chunk_siz
     segment_base_url = config['base_urls']['segment']
     auth_email = config['segment_email']
     auth_password = config['segment_password']
-    projects_to_retire = config['segment_projects']
     workplace_slug = config['segment_workspace_slug']
 
-    segment_api = SegmentApi(segment_base_url, auth_email, auth_password, projects_to_retire, workplace_slug)
+    segment_api = SegmentApi(segment_base_url, auth_email, auth_password, workplace_slug)
 
     # Read the CSV file. Log the number of user rows read.
     with open(retired_users_csv, 'r') as csv_file:

--- a/tubular/scripts/helpers.py
+++ b/tubular/scripts/helpers.py
@@ -169,7 +169,6 @@ def _setup_all_apis_or_exit(fail_func, fail_code, config):
                 segment_base_url,
                 config['segment_email'],
                 config['segment_password'],
-                config['segment_projects'],
                 config['segment_workspace_slug']
             )
     except Exception as exc:  # pylint: disable=broad-except

--- a/tubular/scripts/query_all_segment_deletion_requests.py
+++ b/tubular/scripts/query_all_segment_deletion_requests.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 """
-Command-line script to check status of a bulk delete users request from Segment.
+Command-line script to query all deletion requests made to Segment to check their status.
 """
 from __future__ import absolute_import, unicode_literals
 
@@ -23,7 +23,7 @@ from tubular.scripts.helpers import (
     _log
 )
 
-DEFAULT_CHUNK_SIZE = 5000
+DEFAULT_STATUSES_PER_PAGE = 50
 
 # Return codes for various fail cases
 ERR_NO_CONFIG = -1
@@ -31,7 +31,7 @@ ERR_BAD_CONFIG = -2
 ERR_NO_CSV_FILE = -3
 ERR_QUERYING_STATUS = -4
 
-SCRIPT_SHORTNAME = 'query_segment_bulk_delete_status'
+SCRIPT_SHORTNAME = 'query_all_segment_deletion_requests'
 LOG = partial(_log, SCRIPT_SHORTNAME)
 FAIL = partial(_fail, SCRIPT_SHORTNAME)
 FAIL_EXCEPTION = partial(_fail_exception, SCRIPT_SHORTNAME)
@@ -46,18 +46,19 @@ logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
     help='YAML file that contains retirement-related configuration for this environment.'
 )
 @click.option(
-    '--bulk_delete_id',
-    help='ID from previously-submitted Segment bulk user delete request.'
+    '--per_page',
+    default=DEFAULT_STATUSES_PER_PAGE,
+    help='Number of Segment deletion statuses to return on each page.'
 )
-def query_bulk_delete_id(config_file, bulk_delete_id):
+def query_all_deletion_requests(config_file, per_page):
     """
-    Query the status of a previously-submitted Segment bulk delete request.
+    Query the status of all Segment deletion requests.
     """
     if not config_file:
         FAIL(ERR_NO_CONFIG, 'No config file passed in.')
 
-    LOG('Querying Segment user bulk deletion status for ID "{}" using config file "{}"'.format(
-        bulk_delete_id, config_file
+    LOG('Querying Segment deletion requests using config file "{}"'.format(
+        config_file
     ))
 
     config = CONFIG_OR_EXIT(config_file)
@@ -65,17 +66,16 @@ def query_bulk_delete_id(config_file, bulk_delete_id):
     segment_base_url = config['base_urls']['segment']
     auth_email = config['segment_email']
     auth_password = config['segment_password']
-    projects_to_retire = config['segment_projects']
     workplace_slug = config['segment_workspace_slug']
 
-    segment_api = SegmentApi(segment_base_url, auth_email, auth_password, projects_to_retire, workplace_slug)
+    segment_api = SegmentApi(segment_base_url, auth_email, auth_password, workplace_slug)
 
     try:
-        segment_api.get_bulk_delete_status(bulk_delete_id)
+        segment_api.get_all_deletion_requests(per_page)
     except Exception as exc:  # pylint: disable=broad-except
         FAIL_EXCEPTION(ERR_QUERYING_STATUS, 'Unexpected error occurred!', exc)
 
 
 if __name__ == '__main__':
     # pylint: disable=unexpected-keyword-arg, no-value-for-parameter
-    query_bulk_delete_id(auto_envvar_prefix='RETIREMENT')
+    query_all_deletion_requests(auto_envvar_prefix='RETIREMENT')

--- a/tubular/scripts/query_segment_bulk_delete_status.py
+++ b/tubular/scripts/query_segment_bulk_delete_status.py
@@ -65,10 +65,9 @@ def query_bulk_delete_id(config_file, bulk_delete_id):
     segment_base_url = config['base_urls']['segment']
     auth_email = config['segment_email']
     auth_password = config['segment_password']
-    projects_to_retire = config['segment_projects']
     workplace_slug = config['segment_workspace_slug']
 
-    segment_api = SegmentApi(segment_base_url, auth_email, auth_password, projects_to_retire, workplace_slug)
+    segment_api = SegmentApi(segment_base_url, auth_email, auth_password, workplace_slug)
 
     try:
         segment_api.get_bulk_delete_status(bulk_delete_id)

--- a/tubular/segment_api.py
+++ b/tubular/segment_api.py
@@ -111,11 +111,10 @@ class SegmentApi(object):
     """
     Segment API client with convenience methods
     """
-    def __init__(self, base_url, auth_email, auth_password, projects_to_retire, workspace_slug):
+    def __init__(self, base_url, auth_email, auth_password, workspace_slug):
         self.base_url = base_url
         self.auth_email = auth_email
         self.auth_password = auth_password
-        self.projects_to_retire = projects_to_retire
         self.workspace_slug = workspace_slug
 
     def _get_auth_token(self):

--- a/tubular/tests/retirement_helpers.py
+++ b/tubular/tests/retirement_helpers.py
@@ -66,8 +66,7 @@ def fake_config_file(f, orgs=None, fetch_ecom_segment_id=False):
         },
         'segment_workspace_slug': 'test_slug',
         'segment_email': 'test-segment-retire@edx.org',
-        'segment_password': 'mysegmentpassword',
-        'segment_projects': ['test_project1', 'test_project2', 'test_project3']
+        'segment_password': 'mysegmentpassword'
     }
 
     if fetch_ecom_segment_id:

--- a/tubular/tests/test_segment_api.py
+++ b/tubular/tests/test_segment_api.py
@@ -53,7 +53,7 @@ def setup_bulk_delete():
 
             segment = SegmentApi(
                 *[TEST_SEGMENT_CONFIG[key] for key in [
-                    'fake_base_url', 'fake_email', 'fake_password', 'projects_to_retire', 'fake_workspace'
+                    'fake_base_url', 'fake_email', 'fake_password', 'fake_workspace'
                 ]]
             )
             yield mock_post, segment


### PR DESCRIPTION
The single-user query for the status of all suppress/deletes was implemented as part of debugging the bulk delete failures. So let's keep it? Maybe?

Also, Segment projects are no longer needed in the bulk user delete API - so remove the support for them.