### PR TITLE
Add no-elb mode to retrieve_base_ami.py OPS-3639

### DIFF
--- a/tubular/scripts/retrieve_base_ami.py
+++ b/tubular/scripts/retrieve_base_ami.py
@@ -49,17 +49,13 @@ logging.basicConfig(level=logging.INFO)
     help='Output file for the AMI information yaml.',
     default=None,
 )
-@click.option(
-    '--elb/--no-elb',
-    default=True,
-)
-def retrieve_base_ami(environment, deployment, play, override, out_file, elb):
+def retrieve_base_ami(environment, deployment, play, override, out_file):
     """
     Method used to retrieve the last base AMI ID used for an environment/deployment/play.
     """
 
     try:
-        edp_ami_id = ec2.active_ami_for_edp(environment, deployment, play, has_elb=elb)
+        edp_ami_id = ec2.active_ami_for_edp(environment, deployment, play)
         if override:
             ami_id = override
         else:

--- a/tubular/scripts/retrieve_base_ami.py
+++ b/tubular/scripts/retrieve_base_ami.py
@@ -49,13 +49,17 @@ logging.basicConfig(level=logging.INFO)
     help='Output file for the AMI information yaml.',
     default=None,
 )
-def retrieve_base_ami(environment, deployment, play, override, out_file):
+@click.option(
+    '--elb/--no-elb',
+    default=True,
+)
+def retrieve_base_ami(environment, deployment, play, override, out_file, elb):
     """
     Method used to retrieve the last base AMI ID used for an environment/deployment/play.
     """
 
     try:
-        edp_ami_id = ec2.active_ami_for_edp(environment, deployment, play)
+        edp_ami_id = ec2.active_ami_for_edp(environment, deployment, play, has_elb=elb)
         if override:
             ami_id = override
         else:

--- a/tubular/scripts/retrieve_base_ami.py
+++ b/tubular/scripts/retrieve_base_ami.py
@@ -28,14 +28,17 @@ logging.basicConfig(level=logging.INFO)
 @click.option(
     '--environment', '-e',
     help='Environment for AMI, e.g. prod, stage',
+    required=True,
 )
 @click.option(
     '--deployment', '-d',
     help='Deployment for AMI e.g. edx, edge',
+    required=True,
 )
 @click.option(
     '--play', '-p',
     help='Play for AMI, e.g. edxapp, insights, discovery',
+    required=True,
 )
 @click.option(
     '--override',
@@ -44,17 +47,12 @@ logging.basicConfig(level=logging.INFO)
 @click.option(
     '--out_file',
     help='Output file for the AMI information yaml.',
-    default=None
+    default=None,
 )
 def retrieve_base_ami(environment, deployment, play, override, out_file):
     """
     Method used to retrieve the last base AMI ID used for an environment/deployment/play.
     """
-
-    has_edp = environment is not None or deployment is not None or play is not None
-    if not has_edp:
-        logging.error("Specify --environment, --deployment and --play.")
-        sys.exit(1)
 
     try:
         edp_ami_id = ec2.active_ami_for_edp(environment, deployment, play)

--- a/tubular/tests/test_ec2.py
+++ b/tubular/tests/test_ec2.py
@@ -83,6 +83,7 @@ class TestEC2(unittest.TestCase):
 
     @mock_elb
     @mock_ec2
+    @mock_autoscaling
     def test_ami_for_edp_missing_edp(self):
         # Non-existent EDP
         with self.assertRaises(ImageNotFoundException):


### PR DESCRIPTION
Add --no-elb flag to retrieve_base_ami.py to make it work with backend services that don't have an ELB.