### PR TITLE
Use specified region when connecting to S3 bucket.

### DIFF
--- a/tubular/scripts/retirement_archive_and_cleanup.py
+++ b/tubular/scripts/retirement_archive_and_cleanup.py
@@ -67,7 +67,7 @@ def _on_s3_backoff(details):
     """
     Callback that is called when backoff... backs off
     """
-    LOG("Backing off {wait:0.1f} seconds afters {tries} tries calling function {target}".format(**details))
+    LOG("Backing off {wait:0.1f} seconds after {tries} tries calling function {target}".format(**details))
 
 
 @backoff.on_exception(
@@ -86,7 +86,8 @@ def _upload_to_s3(config, filename):
     try:
         s3_connection = S3Connection(
             config['s3_archive']['access_key'],
-            config['s3_archive']['secret_key']
+            config['s3_archive']['secret_key'],
+            host='s3.{}.amazonaws.com'.format(config['s3_archive']['region'])
         )
 
         datestr = datetime.datetime.now().strftime('%Y/%m/')


### PR DESCRIPTION
https://openedx.atlassian.net/browse/PLAT-2380

I had created a `us-east-2` bucket to test with - this change fixed the 400 errors I got.

After this change, stage-edx was able to successfully archive!:
https://build.testeng.edx.org/job/user-retirement-archiver/4/console