### PR TITLE
Add retrying to the Sailthru delete_user API call.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,16 @@ Please do not report security issues in public. Please email security@edx.org.
 
 |     Variable Name    | Default                         | Description                                                                                   |
 |:--------------------:|---------------------------------|-----------------------------------------------------------------------------------------------|
-| ASGARD_API_ENDPOINTS | http://dummy.url:8091/us-east-1 | fully qualified URL to the asgard instance to run the scripts against                         |
-| ASGARD_API_TOKEN     | dummy-token                     | String - The asgard token                                                                     |
-| ASGARD_WAIT_TIMEOUT  | 600                             | Integer - time in seconds to wait for an action such as instances healthy in a load balancer. |
-| REQUESTS_TIMEOUT     | 10                              | How long to wait for an http connection/response from Asgard.                                 |
-| RETRY_MAX_ATTEMPTS   | 5                               | Integer - Maximum number attempts to be made when asgard returns an error.                    |
-| RETRY_DELAY_SECONDS  | 5                               | How long in seconds to wait between retries to asgard                                         |
-| RETRY_MAX_TIME_SECONDS | None                          | How long in seconds to keep retrying asgard before giving up.                                 |
-| RETRY_FACTOR         | 1.5                             | Factor to multiple the base wait time by per retry attempt.  Only applies to ec2 boto calls   |
-| ASGARD_ELB_HEALTH_TIMEOUT | 600                        | How long in seconds to wait for an instanced to become healthy in an ELB.                     |
+| ASGARD_API_ENDPOINTS | http://dummy.url:8091/us-east-1 | Fully qualified URL for the Asgard instance against which to run the scripts.                 |
+| ASGARD_API_TOKEN     | dummy-token                     | String - The Asgard token.                                                                    |
+| ASGARD_WAIT_TIMEOUT  | 600                             | Integer - Time in seconds to wait for an action such as instances healthy in a load balancer. |
+| REQUESTS_TIMEOUT     | 10                              | How long to wait for an HTTP connection/response from Asgard.                                 |
+| RETRY_MAX_ATTEMPTS   | 5                               | Integer - Maximum number of attempts to be made when Asgard returns an error.                 |
+| RETRY_SAILTHRU_MAX_ATTEMPTS | 5                        | Integer - Maximum number of attempts to be made when Sailthru returns an error.               |
+| RETRY_DELAY_SECONDS  | 5                               | Time in seconds to wait between retries to Asgard.                                            |
+| RETRY_MAX_TIME_SECONDS | None                          | Time in seconds to keep retrying Asgard before giving up.                                     |
+| RETRY_FACTOR         | 1.5                             | Factor by which to multiply the base wait time per retry attempt for EC2 boto calls.          |
+| ASGARD_ELB_HEALTH_TIMEOUT | 600                        | Time in seconds to wait for an EC2 instance to become healthy in an ELB.                      |
 | SHA_LENGTH           | 10                              | Length of the commit SHA to use when querying for a PR by commit.                             |
 | BATCH_SIZE           | 18                              | Number of commits to batch together when querying a PR by commit.                             |
 

--- a/tubular/tests/test_sailthru.py
+++ b/tubular/tests/test_sailthru.py
@@ -1,12 +1,22 @@
 """
 Tests for the Sailthru API functionality
 """
+import os
 import logging
 import mock
 import pytest
+from six.moves import reload_module
 
+# This module is imported separately solely so it can be re-loaded below.
+from tubular import sailthru_api
+# This SailthruApi class will be used without being re-loaded.
 from tubular.sailthru_api import SailthruApi
 from sailthru.sailthru_error import SailthruClientError
+
+# Change the number of retries for Sailthru API's delete_user call to 1.
+# Then reload sailthru_api so only a single retry is performed.
+os.environ['RETRY_SAILTHRU_MAX_ATTEMPTS'] = "1"
+reload_module(sailthru_api)  # pylint: disable=too-many-function-args
 
 
 @pytest.fixture
@@ -23,16 +33,15 @@ def test_sailthru_delete_no_email():
 
 def test_sailthru_delete_client_error(test_learner):  # pylint: disable=redefined-outer-name
     with mock.patch('tubular.sailthru_api.SailthruClient'):
-        sailthru_api = SailthruApi('key', 'secret')
-        sailthru_api._sailthru_client.api_delete.side_effect = SailthruClientError()  # pylint: disable=protected-access
-        with pytest.raises(Exception) as exc:
-            sailthru_api.delete_user(test_learner)
-        assert 'Exception attempting to delete user from Sailthru' in str(exc)
+        reloaded_sailthru_api = sailthru_api.SailthruApi('key', 'secret')  # pylint: disable=redefined-outer-name
+        reloaded_sailthru_api._sailthru_client.api_delete.side_effect = SailthruClientError()  # pylint: disable=protected-access
+        with pytest.raises(SailthruClientError):
+            reloaded_sailthru_api.delete_user(test_learner)
 
 
 def test_sailthru_delete_not_ok_response(test_learner):  # pylint: disable=redefined-outer-name
     with mock.patch('tubular.sailthru_api.SailthruClient'):
-        sailthru_api = SailthruApi('key', 'secret')
+        sailthru_api = SailthruApi('key', 'secret')  # pylint: disable=redefined-outer-name
         mock_response = mock.Mock()
         mock_response.is_ok.return_value = False
         mock_error = mock.Mock()
@@ -51,7 +60,7 @@ def test_sailthru_delete_not_found_response(test_learner, caplog):  # pylint: di
     we should treat as "no action needed".
     """
     with mock.patch('tubular.sailthru_api.SailthruClient'):
-        sailthru_api = SailthruApi('key', 'secret')
+        sailthru_api = SailthruApi('key', 'secret')  # pylint: disable=redefined-outer-name
         mock_response = mock.Mock()
         mock_response.is_ok.return_value = False
         mock_error = mock.Mock()
@@ -65,7 +74,7 @@ def test_sailthru_delete_not_found_response(test_learner, caplog):  # pylint: di
 
 def test_sailthru_success(test_learner, caplog):  # pylint: disable=redefined-outer-name
     with mock.patch('tubular.sailthru_api.SailthruClient'):
-        sailthru_api = SailthruApi('key', 'secret')
+        sailthru_api = SailthruApi('key', 'secret')  # pylint: disable=redefined-outer-name
         mock_response = mock.Mock()
         mock_response.is_ok.return_value = True
         sailthru_api._sailthru_client.api_delete.return_value = mock_response  # pylint: disable=protected-access


### PR DESCRIPTION
https://openedx.atlassian.net/browse/PLAT-2410

The delete_user Sailthru call never had any retry code around it. This PR adds it using the `backoff` module - and effectively turns it off for a test.