### PR TITLE
Added method to call the edx_proctoring endpoint for deleting proctoring data

### DIFF
--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -297,6 +297,14 @@ class LmsApi(BaseApiClient):
             return self._client.api.user.v1.accounts.retirement_partner_report_cleanup.post(**params)
 
     @_retry_lms_api()
+    def retirement_retire_proctoring_data(self, learner):
+        """
+        Removes the given learner from 3rd party proctoring backends
+        """
+        with correct_exception():
+            return self._client.api.edx_proctoring.v1.retire_backend_user(learner['user_id']).post()
+
+    @_retry_lms_api()
     def bulk_cleanup_retirements(self, usernames):
         """
         Deletes the retirements for all given usernames


### PR DESCRIPTION
This depends on [edx_proctoring/517](https://github.com/edx/edx-proctoring/pull/517) landing in production.

