### PR TITLE
Add link to slack room for debugging e2e failures

### DIFF
--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -63,7 +63,9 @@ class MessageType(enum.Enum):
     loadtest_failed = 'This PR failed to deploy to the loadtest environment.'
     loadtest_rollback = 'This PR has been rolled back from the loadtest environment.'
     broke_vagrant = 'This PR may have broken Vagrant Devstack CI.'
-    e2e_failed = 'This PR may have caused e2e tests to fail on Stage.'
+    e2e_failed = "This PR may have caused e2e tests to fail on Stage. " \
+                 "If you're a member of the edX org, please visit #e2e-troubleshooting on Slack to " \
+                 "help diagnose the cause of these failures. Otherwise, it is the reviewer's responsibility."
 
 
 class SearchRateLimitError(Exception):


### PR DESCRIPTION
We want to create a space where people can quickly discuss e2e test failures and figure out if their PR is to blame. Right now the message doesn't have any suggested actions, and leads to confusion about what to do. The Slack room should help with this.