### PR TITLE
[retirement archiver] Make S3 credentials optional

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,8 @@ Calen Pennington <calen.pennington@gmail.com>
 Cory Lee <cl10001123@gmail.com>
 Cory Lee <cory@edx.org>
 Dave Chamberlain <dchamberlain@edx.org>
+Dave St.Germain <dave@st.germa.in>
+Dave St.Germain <dstgermain@edx.org>
 David Ormsbee <dave@edx.org>
 Dillon Dumesnil <ddumesnil@edx.org>
 Dillon Dumesnil <dillon.dumesnil@gmail.com>
@@ -19,12 +21,16 @@ Fred Smith <derf@edx.org>
 Gregory Martin <greg@edx.org>
 Gregory Martin <yro@users.noreply.github.com>
 Isabel <isabelgk@users.noreply.github.com>
-Julia Eskew <jeskew@edx.org>
+Jansen Kantor <jkantor@edx.org>
 Jesse Zoldak <zoldak@edx.org>
 Joseph Mulloy <jdmulloy@users.noreply.github.com>
 Joseph Mulloy <jmulloy@edx.org>
+Julia Eskew <jeskew@edx.org>
 Kevin Falcone <kevin@edx.org>
 Kevin Falcone <kevin@jibsheet.com>
+Luis Moreno <luis.moreno@edunext.co>
+Michael Youngstrom <myoungstrom@edx.org>
+Michael Youngstrom <youngstrom.m@husky.neu.edu>
 Mike Dikan <mike.dikan@gmail.com>
 Nadeem Shahzad <nadem.shahzad@gmail.com>
 Renzo Lucioni <renzo@lucioni.xyz>
@@ -34,5 +40,9 @@ Stu Young <estute@users.noreply.github.com>
 Stuart Young <syoung@edx.org>
 Troy Sankey <sankeytms@gmail.com>
 Troy Sankey <tsankey@edx.org>
+Zia Fazal <zia.fazal@arbisoft.com>
 bmedx <bmesick@edx.org>
+jansenk <jkantor@edx.org>
 nadeemshahzad <nshahzad@edx.org>
+syed-awais-ali <aali@edx.org>
+syed-awais-ali <awaisalisabir@gmail.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,41 @@
 CHANGES
 =======
 
+* [retirement archiver] Make S3 credentials optional
+* add salesforce api and calls to retire user
+* Add link to slack room for debugging e2e failures
+* Added method to call the edx\_proctoring endpoint for deleting proctoring data
+* Remove name from AUTHORS
+* Change name in AUTHORS
+* Update README to add new Sailthru max attempts env var
+* Add retrying to the Sailthru delete\_user API call
+* Use specified region when connecting to S3 bucket
+* Add option for common environment variable file to frontend build script
+* Determine AMI by ASG only
+* Remove elb options, make detection automatic
+* Add no-elb mode to retrieve\_base\_ami.py OPS-3639
+* Cleanup/fix click options to be mandatory
+* fix release advancer
+* Differentiate between required/optional segment user ID keys
+* Add delete\_learner for single user deletion
+* Remove concept of Segment projects - no longer needed for bulk delete
+* Add querying of all suppress and delete user mutations
+* removed hipchat
+* removed hipchat
+* removed hipchat integration
+* pep8 fix
+* rebaes
+* added logic to send notifications to slack
+* added logic to send notifications to slack
+* Remove hipchat from release advancer
+* Add Segment bulk user delete querying functionality
+* Implement review comments. Add test for error case
+* Add script to call Segment bulk user delete & tests
+* Change supress call to bulk delete & change tests
+* Fix to avoid TypeError
+* add purge-cache parameter
+* Avoid logging the email address wherever not necessary
+* Update changelog
 * Wait longer for ASGs to become healthy
 * sailthru deletion: swallow "not found" errors
 * Fix pylint errors caused by new version
@@ -444,4 +479,3 @@ CHANGES
 * Change import filename - oops
 * Initial script implementation
 * Initial commit
-* Removed Hipchat integration

--- a/pylintrc
+++ b/pylintrc
@@ -53,37 +53,294 @@
 #
 # ------------------------------
 [MASTER]
-ignore =
+ignore = 
 persistent = yes
 load-plugins = edx_lint.pylint
 
 [MESSAGES CONTROL]
-disable =
+enable = 
+	blacklisted-name,
+	line-too-long,
+	
+	syntax-error,
+	init-is-generator,
+	return-in-init,
+	function-redefined,
+	not-in-loop,
+	return-outside-function,
+	yield-outside-function,
+	return-arg-in-generator,
+	nonexistent-operator,
+	duplicate-argument-name,
+	abstract-class-instantiated,
+	bad-reversed-sequence,
+	continue-in-finally,
+	method-hidden,
+	access-member-before-definition,
+	no-method-argument,
+	no-self-argument,
+	invalid-slots-object,
+	assigning-non-slot,
+	invalid-slots,
+	inherit-non-class,
+	inconsistent-mro,
+	duplicate-bases,
+	non-iterator-returned,
+	unexpected-special-method-signature,
+	invalid-length-returned,
+	import-error,
+	used-before-assignment,
+	undefined-variable,
+	undefined-all-variable,
+	invalid-all-object,
+	no-name-in-module,
+	unbalance-tuple-unpacking,
+	unpacking-non-sequence,
+	bad-except-order,
+	raising-bad-type,
+	misplaced-bare-raise,
+	raising-non-exception,
+	nonimplemented-raised,
+	catching-non-exception,
+	slots-on-old-class,
+	super-on-old-class,
+	bad-super-call,
+	missing-super-argument,
+	no-member,
+	not-callable,
+	assignment-from-no-return,
+	no-value-for-parameter,
+	too-many-function-args,
+	unexpected-keyword-arg,
+	redundant-keyword-arg,
+	invalid-sequence-index,
+	invalid-slice-index,
+	assignment-from-none,
+	not-context-manager,
+	invalid-unary-operand-type,
+	unsupported-binary-operation,
+	repeated-keyword,
+	not-an-iterable,
+	not-a-mapping,
+	unsupported-membership-test,
+	unsubscriptable-object,
+	logging-unsupported-format,
+	logging-too-many-args,
+	logging-too-few-args,
+	bad-format-character,
+	truncated-format-string,
+	mixed-fomat-string,
+	format-needs-mapping,
+	missing-format-string-key,
+	too-many-format-args,
+	too-few-format-args,
+	bad-str-strip-call,
+	model-unicode-not-callable,
+	super-method-not-called,
+	non-parent-method-called,
+	test-inherits-tests,
+	translation-of-non-string,
+	redefined-variable-type,
+	cyclical-import,
+	unreachable,
+	dangerous-default-value,
+	pointless-statement,
+	pointless-string-statement,
+	expression-not-assigned,
+	duplicate-key,
+	confusing-with-statement,
+	using-constant-test,
+	lost-exception,
+	assert-on-tuple,
+	attribute-defined-outside-init,
+	bad-staticmethod-argument,
+	arguments-differ,
+	signature-differs,
+	abstract-method,
+	super-init-not-called,
+	relative-import,
+	import-self,
+	misplaced-future,
+	invalid-encoded-data,
+	global-variable-undefined,
+	redefined-outer-name,
+	redefined-builtin,
+	redefined-in-handler,
+	undefined-loop-variable,
+	cell-var-from-loop,
+	duplicate-except,
+	nonstandard-exception,
+	binary-op-exception,
+	property-on-old-class,
+	bad-format-string-key,
+	unused-format-string-key,
+	bad-format-string,
+	missing-format-argument-key,
+	unused-format-string-argument,
+	format-combined-specification,
+	missing-format-attribute,
+	invalid-format-index,
+	anomalous-backslash-in-string,
+	anomalous-unicode-escape-in-string,
+	bad-open-mode,
+	boolean-datetime,
+	
+	fatal,
+	astroid-error,
+	parse-error,
+	method-check-failed,
+	django-not-available,
+	raw-checker-failed,
+	django-not-available-placeholder,
+	
+	empty-docstring,
+	invalid-characters-in-docstring,
+	missing-docstring,
+	wrong-spelling-in-comment,
+	wrong-spelling-in-docstring,
+	
+	unused-import,
+	unused-variable,
+	unused-argument,
+	
+	exec-used,
+	eval-used,
+	
+	bad-classmethod-argument,
+	bad-mcs-classmethod-argument,
+	bad-mcs-method-argument,
+	bad-whitespace,
+	consider-iterating-dictionary,
+	consider-using-enumerate,
+	literal-used-as-attribute,
+	multiple-imports,
+	multiple-statements,
+	old-style-class,
+	simplifiable-range,
+	singleton-comparison,
+	superfluous-parens,
+	unidiomatic-typecheck,
+	unneeded-not,
+	wrong-assert-type,
+	simplifiable-if-statement,
+	no-classmethod-decorator,
+	no-staticmethod-decorator,
+	unnecessary-pass,
+	unnecessary-lambda,
+	useless-else-on-loop,
+	unnecessary-semicolon,
+	reimported,
+	global-variable-not-assigned,
+	global-at-module-level,
+	bare-except,
+	broad-except,
+	logging-not-lazy,
+	redundant-unittest-assert,
+	model-missing-unicode,
+	model-has-unicode,
+	model-no-explicit-unicode,
+	protected-access,
+	
+	deprecated-module,
+	deprecated-method,
+	
+	too-many-nested-blocks,
+	too-many-statements,
+	too-many-boolean-expressions,
+	
+	ungrouped-imports,
+	wrong-import-order,
+	wrong-import-position,
+	wildcard-import,
+	
+	missing-final-newline,
+	mixed-line-endings,
+	trailing-newlines,
+	trailing-whitespace,
+	unexpected-line-ending-format,
+	mixed-indentation,
+	
+	bad-option-value,
+	unrecognized-inline-option,
+	useless-suppression,
+	bad-inline-option,
+	deprecated-pragma,
+disable = 
+	bad-continuation,
+	invalid-name,
+	misplaced-comparison-constant,
+	file-ignored,
+	bad-indentation,
+	lowercase-l-suffix,
+	unused-wildcard-import,
+	global-statement,
+	no-else-return,
+	
+	apply-builtin,
+	backtick,
+	basestring-builtin,
+	buffer-builtin,
+	cmp-builtin,
+	cmp-method,
+	coerce-builtin,
+	coerce-method,
+	delslice-method,
+	dict-iter-method,
+	dict-view-method,
+	duplicate-code,
+	execfile-builtin,
+	file-builtin,
+	filter-builtin-not-iterating,
+	fixme,
+	getslice-method,
+	hex-method,
+	import-star-module-level,
+	indexing-exception,
+	input-builtin,
+	intern-builtin,
 	locally-disabled,
 	locally-enabled,
-	too-few-public-methods,
-	bad-builtin,
-	star-args,
-	abstract-class-not-used,
-	abstract-class-little-used,
-	no-init,
-	fixme,
 	logging-format-interpolation,
-	too-many-lines,
+	long-builtin,
+	long-suffix,
+	map-builtin-not-iterating,
+	metaclass-assignment,
+	next-method-called,
+	no-absolute-import,
+	no-init,
 	no-self-use,
-	too-many-ancestors,
-	too-many-instance-attributes,
+	nonzero-method,
+	oct-method,
+	old-division,
+	old-ne-operator,
+	old-octal-literal,
+	old-raise-syntax,
+	parameter-unpacking,
+	print-statement,
+	raising-string,
+	range-builtin-not-iterating,
+	raw_input-builtin,
+	reduce-builtin,
+	reload-builtin,
+	round-builtin,
+	setslice-method,
+	standarderror-builtin,
+	suppressed-message,
 	too-few-public-methods,
+	too-many-ancestors,
+	too-many-arguments,
+	too-many-branches,
+	too-many-instance-attributes,
+	too-many-lines,
+	too-many-locals,
 	too-many-public-methods,
 	too-many-return-statements,
-	too-many-branches,
-	too-many-arguments,
-	too-many-locals,
-	unused-wildcard-import,
-	duplicate-code,
-	no-else-return,
-	bad-option-value,
-	len-as-condition
+	unichr-builtin,
+	unicode-builtin,
+	unpacking-in-except,
+	using-cmp-argument,
+	xrange-builtin,
+	zip-builtin-not-iterating,
 
 [REPORTS]
 output-format = text
@@ -106,11 +363,11 @@ inlinevar-rgx = [A-Za-z_][A-Za-z0-9_]*$
 good-names = f,i,j,k,db,ex,Run,_,__
 bad-names = foo,bar,baz,toto,tutu,tata
 no-docstring-rgx = __.*__$|test_.+|setUp$|setUpClass$|tearDown$|tearDownClass$|Meta$
-docstring-min-length = -1
+docstring-min-length = 5
 
 [FORMAT]
 max-line-length = 120
-ignore-long-lines = ^\s*(# )?<?https?://\S+>?$
+ignore-long-lines = ^\s*(# )?((<?https?://\S+>?)|(\.\. pii: .*))$
 single-line-if-stmt = no
 no-space-check = trailing-comma,dict-separator
 max-module-lines = 1000
@@ -129,7 +386,7 @@ ignore-imports = no
 ignore-mixin-members = yes
 ignored-classes = SQLObject
 unsafe-load-any-extension = yes
-generated-members =
+generated-members = 
 	REQUEST,
 	acl_users,
 	aq_parent,
@@ -155,7 +412,7 @@ generated-members =
 [VARIABLES]
 init-import = no
 dummy-variables-rgx = _|dummy|unused|.*_unused
-additional-builtins =
+additional-builtins = 
 
 [CLASSES]
 defining-attr-methods = __init__,__new__,setUp
@@ -176,11 +433,11 @@ max-public-methods = 20
 
 [IMPORTS]
 deprecated-modules = regsub,TERMIOS,Bastion,rexec
-import-graph =
-ext-import-graph =
-int-import-graph =
+import-graph = 
+ext-import-graph = 
+int-import-graph = 
 
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# 0b9ab7eb3da0c962c3419cf118effcd75e4ca8d9
+# 0168a1f81b76bdc48c1673ae1b59ead003da5778

--- a/tubular/ec2.py
+++ b/tubular/ec2.py
@@ -170,7 +170,7 @@ def active_ami_for_edp(env, dep, play):
         msg = "Multiple AMIs found for {}-{}-{}, should have only one.".format(env, dep, play)
         raise MultipleImagesFoundException(msg)
 
-    if len(amis) == 0:
+    if not amis:
         msg = "No AMIs found for {}-{}-{}.".format(env, dep, play)
         raise ImageNotFoundException(msg)
 
@@ -456,7 +456,7 @@ def terminate_instances(region, tags, max_run_hours, skip_if_tag):
             total_run_time = datetime.utcnow() - datetime.strptime(instance.launch_time[:-1], ISO_DATE_FORMAT)
             if total_run_time > timedelta(hours=max_run_hours) and skip_if_tag not in instance.tags:
                 instances_to_terminate.append(instance.id)
-    if len(instances_to_terminate) > 0:
+    if instances_to_terminate:
         conn.terminate_instances(instance_ids=instances_to_terminate)
     return instances_to_terminate
 
@@ -476,7 +476,7 @@ def wait_for_in_service(all_asgs, timeout):
 
     Returns: Nothing if healthy, raises a timeout exception if un-healthy.
     """
-    if len(all_asgs) == 0:
+    if not all_asgs:
         LOG.info("No ASGs to monitor - skipping health check.")
         return
 
@@ -500,7 +500,7 @@ def wait_for_in_service(all_asgs, timeout):
                 LOG.debug(asgs_left_to_check)
                 asgs_left_to_check.remove(asg.name)
 
-        if len(asgs_left_to_check) == 0:
+        if not asgs_left_to_check:
             return
 
         time.sleep(1)
@@ -542,7 +542,7 @@ def wait_for_healthy_elbs(elbs_to_monitor, timeout):
         """
         return selected_elb.get_instance_health()
 
-    if len(elbs_to_monitor) == 0:
+    if not elbs_to_monitor:
         LOG.info("No ELBs to monitor - skipping health check.")
         return
 
@@ -565,7 +565,7 @@ def wait_for_healthy_elbs(elbs_to_monitor, timeout):
                 elbs_left.remove(elb.name)
 
         LOG.info("Number of load balancers remaining with unhealthy instances: {}".format(len(elbs_left)))
-        if len(elbs_left) == 0:
+        if not elbs_left:
             LOG.info("All instances in all ELBs are healthy, returning.")
             return
         time.sleep(WAIT_SLEEP_TIME)

--- a/tubular/modulestore.py
+++ b/tubular/modulestore.py
@@ -164,7 +164,7 @@ class ModuleStore(object):
         # establish the query filter  (respecting cases where no value is specified)
         query_filter = {}
 
-        if len(doc_filter['$in']) > 0:
+        if doc_filter['$in']:
             query_filter = {"_id": doc_filter}
 
         return query_filter
@@ -450,7 +450,7 @@ class ModuleStore(object):
                         structures)
 
                     # only add the tree if it has 1+ element
-                    if len(version_ancestry_list) > 0:
+                    if version_ancestry_list:
 
                         status_message = "Processing Active Version %s | %s: %s version with a %s-version tree"
 

--- a/tubular/scripts/delete_expired_partner_gdpr_reports.py
+++ b/tubular/scripts/delete_expired_partner_gdpr_reports.py
@@ -45,7 +45,7 @@ def _config_or_exit(config_file, google_secrets_file):
     """
     try:
         with io.open(config_file, 'r') as config:
-            config = yaml.load(config)
+            config = yaml.safe_load(config)
 
         # Check required value
         if 'drive_partners_folder' not in config or not config['drive_partners_folder']:

--- a/tubular/scripts/get_learners_to_retire.py
+++ b/tubular/scripts/get_learners_to_retire.py
@@ -58,7 +58,7 @@ def get_learners_to_retire(config_file,
         exit(-1)
 
     with io.open(config_file, 'r') as config:
-        config_yaml = yaml.load(config)
+        config_yaml = yaml.safe_load(config)
 
     user_count_error_threshold = int(user_count_error_threshold)
     cool_off_days = int(cool_off_days)

--- a/tubular/scripts/helpers.py
+++ b/tubular/scripts/helpers.py
@@ -73,7 +73,7 @@ def _config_or_exit(fail_func, fail_code, config_file):
     """
     try:
         with io.open(config_file, 'r') as config:
-            config = yaml.load(config)
+            config = yaml.safe_load(config)
 
         return config
     except Exception as exc:  # pylint: disable=broad-except
@@ -86,7 +86,7 @@ def _config_with_drive_or_exit(fail_func, config_fail_code, google_fail_code, co
     """
     try:
         with io.open(config_file, 'r') as config:
-            config = yaml.load(config)
+            config = yaml.safe_load(config)
 
         # Check required values
         for var in ('org_partner_mapping', 'drive_partners_folder'):

--- a/tubular/scripts/retirement_archive_and_cleanup.py
+++ b/tubular/scripts/retirement_archive_and_cleanup.py
@@ -84,9 +84,15 @@ def _upload_to_s3(config, filename):
     Upload the archive file to S3
     """
     try:
+        s3_credentials = ()
+        if 'access_key' in config['s3_archive']:
+            s3_credentials = (
+                config['s3_archive']['access_key'],
+                config['s3_archive']['secret_key'],
+            )
+
         s3_connection = S3Connection(
-            config['s3_archive']['access_key'],
-            config['s3_archive']['secret_key'],
+            *s3_credentials,
             host='s3.{}.amazonaws.com'.format(config['s3_archive']['region'])
         )
 

--- a/tubular/scripts/retirement_partner_report.py
+++ b/tubular/scripts/retirement_partner_report.py
@@ -263,7 +263,7 @@ def _add_comments_to_files(config, file_ids):
 
     file_ids_and_comments = []
     for partner in file_ids:
-        if len(external_emails[partner]) == 0:
+        if not external_emails[partner]:
             LOG(
                 'WARNING: could not find a POC for the following partner: "{}". '
                 'Double check the partner folder permissions in Google Drive.'

--- a/tubular/scripts/vagrant_devstack_healthcheck.py
+++ b/tubular/scripts/vagrant_devstack_healthcheck.py
@@ -79,7 +79,7 @@ def check_health():
         except URLError:
             failed_services.append((service, 'Connection Refused! Is the service running and the port correct?'))
 
-    if len(failed_services) > 0:
+    if failed_services:
         print("The following services have failed their health checks:")
         print(failed_services)
         exit(1)

--- a/tubular/splitmongo.py
+++ b/tubular/splitmongo.py
@@ -469,12 +469,10 @@ class SplitMongoBackend(object):
         for av_doc in self._active_versions.find():
             for branch, obj_id in av_doc['versions'].items():
                 structure_id = str(obj_id)
-                # pylint: disable=redefined-variable-type
                 if branch == 'library':
                     key = LibraryLocator(av_doc['org'], av_doc['course'])
                 else:
                     key = CourseLocator(av_doc['org'], av_doc['course'], av_doc['run'])
-                # pylint: disable=redefined-variable-type
 
                 branches.append(
                     ActiveVersionBranch(

--- a/tubular/tests/retirement_helpers.py
+++ b/tubular/tests/retirement_helpers.py
@@ -49,7 +49,7 @@ def fake_config_file(f, orgs=None, fetch_ecom_segment_id=False):
             'credentials': 'https://credentials.stage.edx.org/',
             'lms': 'https://stage-edx-edxapp.edx.org/',
             'ecommerce': 'https://ecommerce.stage.edx.org/',
-            'segment': 'https://segment.invalid/graphql'
+            'segment': 'https://segment.invalid/graphql',
         },
         'retirement_pipeline': TEST_RETIREMENT_PIPELINE,
         'partner_report_platform_name': TEST_PLATFORM_NAME,
@@ -61,8 +61,6 @@ def fake_config_file(f, orgs=None, fetch_ecom_segment_id=False):
         's3_archive': {
             'bucket_name': 'fake_test_bucket',
             'region': 'fake_region',
-            'access_key': 'fake_access_key',
-            'secret_key': 'fake_secret_key'
         },
         'segment_workspace_slug': 'test_slug',
         'segment_email': 'test-segment-retire@edx.org',

--- a/tubular/tests/test_retirement_partner_report.py
+++ b/tubular/tests/test_retirement_partner_report.py
@@ -114,7 +114,7 @@ def _call_script(expect_success=True, config_orgs=None):
                         rows.append(row)
 
                 # Confirm that there are rows at all
-                assert len(rows)
+                assert rows
     return result
 
 


### PR DESCRIPTION
This will be necessary for systems which do not require s3 credentials
to be explicitly passed (i.e. they are inferred from the environment).

Also:

* Synchronize pylintrc with the latest version.
* Update all yaml.load() calls to yaml.safe_load() to make pylint happy.
* Update instances of len() inside if-conditions to make pylint happy.
* Remove instances of ignoring pylint redefined-variable-type.

PLAT-2418