### PR TITLE
Upgrade pyyaml to use latest secure release.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ lxml==3.8.0
 PyGithub==1.29
 pymongo==3.5.1
 pytz==2016.10
-pyyaml==3.12
+pyyaml==5.1
 requests>=2.9.1,<3.0
 sailthru-client
 six


### PR DESCRIPTION
Fixes this alert:
https://github.com/edx/tubular/network/alert/requirements.txt/pyyaml/open