### PR TITLE
Fix message PR github rate limit backoff

### DIFF
--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -219,6 +219,13 @@ class GitHubAPI(object):
         if include_contexts is not None:
             self.include_contexts = re.compile(include_contexts)
 
+    def get_rate_limit(self):
+        """
+        Returns the rate limit and remaining calls before the limit is hit
+        Example: RateLimit(rate=Rate(remaining=4767, limit=5000))
+        """
+        return self.github_connection.get_rate_limit()
+
     def clone(self, branch=None, reference_repo=None):
         """
         Clone this Github repo as a LocalGitAPI instance.

--- a/tubular/scripts/message_prs_in_range.py
+++ b/tubular/scripts/message_prs_in_range.py
@@ -22,6 +22,11 @@ from github.GithubException import RateLimitExceededException, GithubException  
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 LOG = logging.getLogger(__name__)
 
+def backoff_handler(details):
+    LOG.warn("Backing off {wait:0.1f} seconds afters {tries} tries "
+           "calling function {target} with args {args} and kwargs "
+           "{kwargs}".format(**details))
+
 
 @click.command()
 @click.option(
@@ -126,7 +131,10 @@ def message_pull_requests(org,
         message_pr(api, MessageType[message_type], pull_request, extra_text)
 
 
-@backoff.on_exception(backoff.expo, (RateLimitExceededException, socket.timeout), max_tries=7)
+# Backoff switched to default jitter being max_jitter which is rand(0, max) which is undesirable in this case because
+# it can give a pattern like [1, 2, 1, 4, 6, 30, etc.] when we really want something closer to [1, 2, 4, 8, 16, etc.]
+@backoff.on_exception(backoff.expo, (RateLimitExceededException, socket.timeout), max_tries=7,
+                      jitter=backoff.random_jitter, on_backoff=backoff_handler)
 def get_client(org, repo, token):
     u"""
     Returns the github client, pointing at the repo specified
@@ -143,7 +151,10 @@ def get_client(org, repo, token):
     return api
 
 
-@backoff.on_exception(backoff.expo, (RateLimitExceededException, socket.timeout), max_tries=7)
+# Backoff switched to default jitter being max_jitter which is rand(0, max) which is undesirable in this case because
+# it can give a pattern like [1, 2, 1, 4, 6, 30, etc.] when we really want something closer to [1, 2, 4, 8, 16, etc.]
+@backoff.on_exception(backoff.expo, (RateLimitExceededException, socket.timeout), max_tries=7,
+                      jitter=backoff.random_jitter, on_backoff=backoff_handler)
 def retrieve_pull_requests(api, base_sha, head_sha):
     u"""
     Use the github API to retrieve pull requests between the BASE and HEAD SHA specified.
@@ -161,7 +172,10 @@ def retrieve_pull_requests(api, base_sha, head_sha):
     return pull_requests
 
 
-@backoff.on_exception(backoff.expo, GithubException, max_tries=5)
+# Backoff switched to default jitter being max_jitter which is rand(0, max) which is undesirable in this case because
+# it can give a pattern like [1, 2, 1, 4, 6, 30, etc.] when we really want something closer to [1, 2, 4, 8, 16, etc.]
+@backoff.on_exception(backoff.expo, GithubException, max_tries=5, jitter=backoff.random_jitter,
+                      on_backoff=backoff_handler)
 def message_pr(api, message_type, pull_request, extra_text):
     u"""
     Send a Message for a Pull request.

--- a/tubular/scripts/message_prs_in_range.py
+++ b/tubular/scripts/message_prs_in_range.py
@@ -120,6 +120,7 @@ def message_pull_requests(org,
         _, _, head_sha = version.partition(u' ')
 
     api = get_client(org, repo, token)
+    LOG.info("Github API Rate Limit: {}".format(api.get_rate_limit()))
     pull_requests = retrieve_pull_requests(api, base_sha, head_sha)
     for pull_request in pull_requests:
         message_pr(api, MessageType[message_type], pull_request, extra_text)
@@ -155,6 +156,7 @@ def retrieve_pull_requests(api, base_sha, head_sha):
     Returns:
         An array of pull request objects
     """
+    LOG.info("Github API Rate Limit: {}".format(api.get_rate_limit()))
     pull_requests = api.get_pr_range(base_sha, head_sha)
     return pull_requests
 
@@ -175,6 +177,7 @@ def message_pr(api, message_type, pull_request, extra_text):
     Returns:
         None
     """
+    LOG.info("Github API Rate Limit: {}".format(api.get_rate_limit()))
     LOG.info(u"Posting message type %r to %d.", message_type.name, pull_request.number)
     api.message_pr_with_type(pr_number=pull_request, message_type=message_type, extra_text=extra_text)
 


### PR DESCRIPTION
Backoff switched to using "full_jitter" which picks a random value between 0 and max, so it doesn't backoff properly and fails, especially when there's a lot of PRs.