### PR TITLE
feat: add npm package overrides to frontend builder

### DIFF
--- a/tubular/scripts/frontend_utils.py
+++ b/tubular/scripts/frontend_utils.py
@@ -53,10 +53,19 @@ class FrontendBuilder:
 
     def install_requirements(self):
         """ Install requirements for app to build """
-        proc = subprocess.Popen(['npm install'], cwd=self.app_name, shell=True)
+        proc = subprocess.Popen(['npm install -g npm && npm install'], cwd=self.app_name, shell=True)
         return_code = proc.wait()
         if return_code != 0:
-            self.FAIL('Could not run `npm install` for app {}.'.format(self.app_name))
+            self.FAIL('Could not run `npm install -g npm && npm install` for app {}.'.format(self.app_name))
+        npm_overrides = self.get_override_config()
+        if npm_overrides:
+            aliased_installs = ' '.join(['{}@{}'.format(k, v) for k, v in npm_overrides.items()])
+            override_proc = subprocess.Popen(['npm install {}'.format(aliased_installs)], cwd=self.app_name, shell=True)
+            override_proc_return_code = override_proc.wait()
+            if override_proc_return_code != 0:
+                self.FAIL('Could not run `npm install` overrides {} for app {}.'.format(
+                    aliased_installs, self.app_name
+                ))
 
     def get_app_config(self):
         """ Combines the common and environment configs APP_CONFIG data """
@@ -65,6 +74,14 @@ class FrontendBuilder:
         if not app_config:
             self.LOG('Config variables do not exist for app {}.'.format(self.app_name))
         return app_config
+
+    def get_override_config(self):
+        """ Combines the common and environment configs NPM_OVERRIDES data """
+        override_config = self.common_cfg.get('NPM_OVERRIDES', {})
+        override_config.update(self.env_cfg.get('NPM_OVERRIDES', {}))
+        if not override_config:
+            self.LOG('No npm package overrides defined in config.')
+        return override_config
 
     def build_app(self, env_vars, fail_msg):
         """ Builds the app with environment variable."""

--- a/tubular/scripts/frontend_utils.py
+++ b/tubular/scripts/frontend_utils.py
@@ -58,9 +58,9 @@ class FrontendBuilder:
         if return_code != 0:
             self.FAIL('Could not run `npm install` for app {}.'.format(self.app_name))
 
-        self.install_npm_alias_requirements()
+        self.install_requirements_npm_aliases()
 
-    def install_npm_alias_requirements(self):
+    def install_requirements_npm_aliases(self):
         """ Install npm alias requirements for app to build """
         npm_aliases = self.get_npm_aliases_config()
         if npm_aliases:
@@ -71,6 +71,7 @@ class FrontendBuilder:
                 self.FAIL('Could not run `npm install npm` for app {}.'.format(self.app_name))
 
             aliased_installs = ' '.join(['{}@{}'.format(k, v) for k, v in npm_aliases.items()])
+            # Use the locally installed npm at ./node_modules/.bin/npm
             install_aliases_proc = subprocess.Popen(
                 ['./node_modules/.bin/npm install {}'.format(aliased_installs)],
                 cwd=self.app_name,

--- a/tubular/scripts/frontend_utils.py
+++ b/tubular/scripts/frontend_utils.py
@@ -53,10 +53,10 @@ class FrontendBuilder:
 
     def install_requirements(self):
         """ Install requirements for app to build """
-        proc = subprocess.Popen(['npm install -g npm && npm install'], cwd=self.app_name, shell=True)
+        proc = subprocess.Popen(['npm install npm && npm install'], cwd=self.app_name, shell=True)
         return_code = proc.wait()
         if return_code != 0:
-            self.FAIL('Could not run `npm install -g npm && npm install` for app {}.'.format(self.app_name))
+            self.FAIL('Could not run `npm install npm && npm install` for app {}.'.format(self.app_name))
         npm_overrides = self.get_override_config()
         if npm_overrides:
             aliased_installs = ' '.join(['{}@{}'.format(k, v) for k, v in npm_overrides.items()])

--- a/tubular/scripts/frontend_utils.py
+++ b/tubular/scripts/frontend_utils.py
@@ -53,17 +53,17 @@ class FrontendBuilder:
 
     def install_requirements(self):
         """ Install requirements for app to build """
-        proc = subprocess.Popen(['npm install npm && npm install'], cwd=self.app_name, shell=True)
+        proc = subprocess.Popen(['npm install'], cwd=self.app_name, shell=True)
         return_code = proc.wait()
         if return_code != 0:
-            self.FAIL('Could not run `npm install npm && npm install` for app {}.'.format(self.app_name))
+            self.FAIL('Could not run `npm install` for app {}.'.format(self.app_name))
         npm_overrides = self.get_override_config()
         if npm_overrides:
             aliased_installs = ' '.join(['{}@{}'.format(k, v) for k, v in npm_overrides.items()])
-            override_proc = subprocess.Popen(['npm install {}'.format(aliased_installs)], cwd=self.app_name, shell=True)
+            override_proc = subprocess.Popen(['npm install npm && ./node_modules/.bin/npm install {}'.format(aliased_installs)], cwd=self.app_name, shell=True)
             override_proc_return_code = override_proc.wait()
             if override_proc_return_code != 0:
-                self.FAIL('Could not run `npm install` overrides {} for app {}.'.format(
+                self.FAIL('Could not run `npm install npm && npm install` overrides {} for app {}.'.format(
                     aliased_installs, self.app_name
                 ))
 


### PR DESCRIPTION
Consume config to override npm packages, leveraging npm aliases.

Sample config in edx-internal: https://github.com/edx/edx-internal/blob/pipeline-test/frontends/frontend-app-profile/stage_config.yml
```
APP_CONFIG:
  # 
  # 
NPM_ALIASES:
  "@edx/frontend-component-open-edx-header": "npm:@edx/frontend-component-edx-header"
```