### PR TITLE
fix bug for retirement partner job in py 35

### DIFF
--- a/tubular/utils/__init__.py
+++ b/tubular/utils/__init__.py
@@ -43,6 +43,7 @@ def batch(batchable, batch_size=1):
     Yields:
         list
     """
-    length = len(batchable)
+    batchable_list = list(batchable)
+    length = len(batchable_list)
     for index in range(0, length, batch_size):
-        yield batchable[index:index + batch_size]
+        yield batchable_list[index:index + batch_size]


### PR DESCRIPTION
We recently started running retirement jobs w/ python3.5. The first run of the partner reporter job failed with the following error message:
```
Partner report: Traceback (most recent call last):
  File "scripts/retirement_partner_report.py", line 339, in generate_report
    _add_comments_to_files(config, report_file_ids)
  File "scripts/retirement_partner_report.py", line 242, in _add_comments_to_files
    fields=\'emailAddress\',
  File "/home/jenkins/workspace/retirement-partner-reporter/tubular/tubular/google_api.py", line 478, in list_permissions_for_files
    for file_ids_batch in batch(file_ids, batch_size=GOOGLE_API_MAX_BATCH_SIZE):
  File "/home/jenkins/workspace/retirement-partner-reporter/tubular/tubular/utils/__init__.py", line 48, in batch
    yield batchable[index:index + batch_size]
TypeError: \'odict_values\' object is not subscriptable
```
This should fix it