### PR TITLE
Add retirement endpoint for PII owned by edx-proctoring

### DIFF
--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -299,6 +299,14 @@ class LmsApi(BaseApiClient):
     @_retry_lms_api()
     def retirement_retire_proctoring_data(self, learner):
         """
+        Deletes or hashes learner data from edx-proctoring
+        """
+        with correct_exception():
+            return self._client.api.edx_proctoring.v1.retire_user(learner['user']['id']).post()
+
+    @_retry_lms_api()
+    def retirement_retire_proctoring_backend_data(self, learner):
+        """
         Removes the given learner from 3rd party proctoring backends
         """
         with correct_exception():


### PR DESCRIPTION
JIRA: [EDUCATOR-4776](https://openedx.atlassian.net/browse/EDUCATOR-4776)
Linked PR: [edx/edx-proctoring #657](https://github.com/edx/edx-proctoring/pull/657)

**Note:** This should not be merged until the above PR has been released to production

Currently, data can be retired from proctoring backends. This adds missing endpoint to retire user personally-identifiable information (PII) maintained inside of edx-proctoring directly.