### PR TITLE
Backoff on MultipleImagesFoundException.

### DIFF
--- a/tubular/ec2.py
+++ b/tubular/ec2.py
@@ -115,7 +115,7 @@ def _instance_elbs(instance_id, elbs):
 
 
 @backoff.on_exception(backoff.expo,
-                      BotoServerError,
+                      (BotoServerError, MultipleImagesFoundException),
                       max_tries=MAX_ATTEMPTS,
                       giveup=giveup_if_not_throttling,
                       factor=RETRY_FACTOR)


### PR DESCRIPTION
This exception can be thrown if the cluster we care about is in a bad
state but it can also be thrown when a deploy is happening.  Also doing
a backoff when we see this exception should make us more resilient to
running this while a deploy is happening.