### PR TITLE
Retry on BackendErro when waiting for task completion.

### DIFF
--- a/tubular/asgard.py
+++ b/tubular/asgard.py
@@ -179,7 +179,7 @@ def asgs_for_cluster(cluster):
 
 
 @backoff.on_exception(backoff.expo,
-                      (RateLimitedException,),
+                      (RateLimitedException, BackendError),
                       max_tries=MAX_ATTEMPTS)
 def wait_for_task_completion(task_url, timeout):
     """


### PR DESCRIPTION
Since waiting for task completion is an idempotent operation that
doesn't have any side effects, we can retry it safely if the backend has
errors.  The same is not true for all asgard operations but it is fine
for this one.