### PR TITLE
Ignore the dependabot context on test status.

### DIFF
--- a/tubular/scripts/check_pr_tests_status.py
+++ b/tubular/scripts/check_pr_tests_status.py
@@ -63,7 +63,7 @@ LOG = logging.getLogger(__name__)
 @click.option(
     '--exclude-contexts',
     help=u"Regex defining which validation contexts to exclude from this status check.",
-    default="datreeio|Renovate|Codecov"
+    default="datreeio|Renovate|[Cc]odecov|Dependabot"
 )
 @click.option(
     '--include-contexts',

--- a/tubular/scripts/poll_pr_tests_status.py
+++ b/tubular/scripts/poll_pr_tests_status.py
@@ -56,7 +56,7 @@ LOG = logging.getLogger(__name__)
 @click.option(
     '--exclude-contexts',
     help=u"Regex defining which validation contexts to exclude from this status check.",
-    default="datreeio|Renovate|[Cc]odecov"
+    default="datreeio|Renovate|[Cc]odecov|Dependabot"
 )
 @click.option(
     '--include-contexts',


### PR DESCRIPTION
It seems to be putting a context on the master commit via the API that
is not visible through github UI but is causig our deploy pipelines to
fail because it remains in pending state for a long time.

We don't want to block deploys on whether or not dependabot has run some
check on master.