### PR TITLE
Add retry to Salesforce api call

### DIFF
--- a/pip-tools.txt
+++ b/pip-tools.txt
@@ -5,8 +5,8 @@
 #    pip-compile --no-emit-trusted-host --no-index pip-tools.in
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.1.2          # via -r pip-tools.in
-six==1.14.0               # via pip-tools
+pip-tools==5.2.0          # via -r pip-tools.in
+six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --no-emit-trusted-host --no-index requirements.in
 #
-atlassian-python-api==1.15.6  # via -r requirements.in
-authlib==0.14.2           # via simple-salesforce
+atlassian-python-api==1.15.7  # via -r requirements.in
+authlib==0.14.3           # via simple-salesforce
 backoff==1.5.0            # via -r requirements.in
 boto==2.43.0              # via -r requirements.in
 cachetools==4.1.0         # via google-auth
@@ -17,7 +17,7 @@ click==6.7                # via -r requirements.in, click-log
 cloudflare==2.1.0         # via -r requirements.in
 cryptography==2.9.2       # via authlib
 decorator==4.4.2          # via validators
-deprecated==1.2.9         # via pygithub
+deprecated==1.2.10        # via pygithub
 easydict==1.9             # via yagocd
 edx-opaque-keys==0.4.0    # via -r requirements.in
 edx-rest-api-client==1.7.1  # via -r requirements.in
@@ -27,12 +27,12 @@ gitdb==4.0.5              # via gitpython
 gitpython==3.1.2          # via -r requirements.in
 google-api-python-client==1.7.3  # via -r requirements.in
 google-auth-httplib2==0.0.3  # via google-api-python-client
-google-auth==1.14.2       # via google-api-python-client, google-auth-httplib2
-httplib2==0.17.3          # via google-api-python-client, google-auth-httplib2
+google-auth==1.15.0       # via google-api-python-client, google-auth-httplib2
+httplib2==0.18.1          # via google-api-python-client, google-auth-httplib2
 idna==2.9                 # via requests
 jenkinsapi==0.3.3         # via -r requirements.in
 jsonlines==1.2.0          # via cloudflare
-lxml==4.5.0               # via -r requirements.in
+lxml==4.5.1               # via -r requirements.in
 oauthlib==3.1.0           # via atlassian-python-api, requests-oauthlib
 pbr==5.4.5                # via stevedore
 pyasn1-modules==0.2.8     # via google-auth
@@ -50,7 +50,7 @@ rsa==4.0                  # via google-auth
 sailthru-client==2.3.5    # via -r requirements.in
 simple-salesforce==1.0.0  # via -r requirements.in
 simplejson==3.17.0        # via sailthru-client
-six==1.14.0               # via -r requirements.in, atlassian-python-api, cryptography, edx-opaque-keys, freezegun, google-api-python-client, google-auth, jsonlines, python-dateutil, stevedore, validators, yagocd
+six==1.15.0               # via -r requirements.in, atlassian-python-api, cryptography, edx-opaque-keys, freezegun, google-api-python-client, google-auth, jsonlines, python-dateutil, stevedore, validators, yagocd
 slumber==0.7.1            # via edx-rest-api-client
 smmap==3.0.4              # via gitdb
 stevedore==1.32.0         # via edx-opaque-keys


### PR DESCRIPTION
A recent retirement user failed in the pipeline due to a failed API call that did not have retry logic around it. Add logic to retry the call.

Also, upgrade the requirements to fix this vulnerability alert:
https://github.com/edx/tubular/network/alerts