### PR TITLE
Tag releases to ensure they are not pruned prematurely.

### DIFF
--- a/tubular/git_repo.py
+++ b/tubular/git_repo.py
@@ -156,6 +156,13 @@ class LocalGitAPI:
             self.repo.git.merge(*commitishes)
         return self.get_head_sha()
 
+    def push_tags(self, remote='origin', force=False):
+        """
+        Push all local tags up to the remote repo.
+        """
+        push_ref = 'refs/tags/*'
+        self.repo.remotes[remote].push(push_ref, force=force)
+
     def force_branch_to(self, branch, commitish, remote=None):
         """
         Reset branch to commitish.

--- a/tubular/scripts/merge_approved_prs.py
+++ b/tubular/scripts/merge_approved_prs.py
@@ -3,6 +3,7 @@
 """
 Command-line script to trigger a jenkins job
 """
+from datetime import datetime
 import logging
 import sys
 import os
@@ -132,7 +133,14 @@ def octomerge(
         ))
 
         merge_sha = local_repo.octopus_merge(target_branch, (pr.head.sha for pr in approved_prs))
+        # The tag encodes the time to ensure that it is a distinct tag.
+        release_name = 'release-{date}'.format(date=datetime.now().strftime("%Y%m%d%H%M%S"))
+        local_repo.repo.create_tag(
+            release_name,
+            ref=merge_sha,
+        )
         local_repo.push_branch(target_branch, force=True)
+        local_repo.push_tags()
 
         results = {
             'target_branch': target_branch,


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ARCHBOM-1265

creating tags with gitpython: https://gitpython.readthedocs.io/en/stable/tutorial.html#advanced-repo-usage

push based on the `push_branch` method, just changing it to use the tags reference instead: https://github.com/edx/tubular/blob/b4740909f8ee4905ccdfb57d0db56d862f342a28/tubular/git_repo.py#L79-L87
