### PR TITLE
MICROBA-447 | Add logging for demographics retirement

### DIFF
--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -435,4 +435,5 @@ class DemographicsApi(BaseApiClient):
             with correct_exception():
                 return self._client.demographics.api.v1.retire_demographics.post(**params)
         except HttpNotFoundError:
+            LOG.info("No demographics data found for user")
             return True


### PR DESCRIPTION
[MICROBA-447]
- Add logging when no data is found for user during demographics retirement.