### PR TITLE
Revert "Allow HubspotAPI to send email to marketing upon successful deletion"

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,6 @@
 CHANGES
 =======
 
-* MST-482 - Send email alert upon successful Hubspot deletion
 * ISRE-588 - update javasocketerror raise logic
 * ISRE-587 - update giveup logic
 * Fix tox/pytest

--- a/tubular/scripts/helpers.py
+++ b/tubular/scripts/helpers.py
@@ -165,9 +165,6 @@ def _setup_all_apis_or_exit(fail_func, fail_code, config):
         segment_auth_token = config.get('segment_auth_token', None)
         segment_workspace_slug = config.get('segment_workspace_slug', None)
         hubspot_api_key = config.get('hubspot_api_key', None)
-        hubspot_aws_region = config.get('hubspot_aws_region', None)
-        hubspot_from_address = config.get('hubspot_from_address', None)
-        hubspot_alert_email = config.get('hubspot_alert_email', None)
 
         for state in config['retirement_pipeline']:
             for service, service_url in (
@@ -196,12 +193,7 @@ def _setup_all_apis_or_exit(fail_func, fail_code, config):
             )
 
         if hubspot_api_key:
-            config['HUBSPOT'] = HubspotAPI(
-                hubspot_api_key,
-                hubspot_aws_region,
-                hubspot_from_address,
-                hubspot_alert_email
-            )
+            config['HUBSPOT'] = HubspotAPI(hubspot_api_key)
 
         if ecommerce_base_url:
             config['ECOMMERCE'] = EcommerceApi(lms_base_url, ecommerce_base_url, client_id, client_secret)

--- a/tubular/tests/test_hubspot.py
+++ b/tubular/tests/test_hubspot.py
@@ -5,7 +5,7 @@ import os
 import logging
 import unittest
 
-from unittest import mock
+import mock
 import requests_mock
 from six.moves import reload_module
 
@@ -22,7 +22,6 @@ reload_module(hubspot_api)  # pylint: disable=too-many-function-args
 
 
 @requests_mock.Mocker()
-@mock.patch.object(HubspotAPI, 'send_marketing_alert')
 class TestHubspot(unittest.TestCase):
     """
     Class containing tests of all code interacting with Hubspot.
@@ -32,9 +31,6 @@ class TestHubspot(unittest.TestCase):
         self.test_learner = {'original_email': 'foo@bar.com'}
         self.api_key = 'example_key'
         self.test_vid = 12345
-        self.test_region = 'test-east-1'
-        self.from_address = 'no-reply@example.com'
-        self.alert_email = 'marketing@example.com'
 
     def _mock_get_vid(self, req_mock, status_code):
         req_mock.get(
@@ -56,106 +52,57 @@ class TestHubspot(unittest.TestCase):
             status_code=status_code
         )
 
-    def test_delete_no_email(self, req_mock, mock_alert):  # pylint: disable=unused-argument
+    def test_delete_no_email(self, req_mock):  # pylint: disable=unused-argument
         with self.assertRaises(TypeError) as exc:
-            HubspotAPI(
-                self.api_key,
-                self.test_region,
-                self.from_address,
-                self.alert_email
-            ).delete_user({})
+            HubspotAPI(self.api_key).delete_user({})
             self.assertIn('Expected an email address for user to delete, but received None.', str(exc))
-            mock_alert.assert_not_called()
 
-    def test_delete_success(self, req_mock, mock_alert):
+    def test_delete_success(self, req_mock):
         self._mock_get_vid(req_mock, 200)
         self._mock_delete(req_mock, 200)
         logger = logging.getLogger('tubular.hubspot_api')
-
         with mock.patch.object(logger, 'info') as mock_info:
-            HubspotAPI(
-                self.api_key,
-                self.test_region,
-                self.from_address,
-                self.alert_email
-            ).delete_user(self.test_learner)
+            HubspotAPI(self.api_key).delete_user(self.test_learner)
             mock_info.assert_called_once_with("User successfully deleted from Hubspot")
-            mock_alert.assert_called_once_with(12345)
 
-    def test_delete_email_does_not_exist(self, req_mock, mock_alert):
+    def test_delete_email_does_not_exist(self, req_mock):
         self._mock_get_vid(req_mock, 404)
         logger = logging.getLogger('tubular.hubspot_api')
         with mock.patch.object(logger, 'info') as mock_info:
-            HubspotAPI(
-                self.api_key,
-                self.test_region,
-                self.from_address,
-                self.alert_email
-            ).delete_user(self.test_learner)
+            HubspotAPI(self.api_key).delete_user(self.test_learner)
             mock_info.assert_called_once_with("No action taken because no user was found in Hubspot.")
-            mock_alert.assert_not_called()
 
-    def test_delete_server_failure_on_user_retrieval(self, req_mock, mock_alert):
+    def test_delete_server_failure_on_user_retrieval(self, req_mock):
         self._mock_get_vid(req_mock, 500)
         with self.assertRaises(hubspot_api.HubspotException) as exc:
-            HubspotAPI(
-                self.api_key,
-                self.test_region,
-                self.from_address,
-                self.alert_email
-            ).delete_user(self.test_learner)
+            HubspotAPI(self.api_key).delete_user(self.test_learner)
             self.assertIn("Error attempted to get user_vid from Hubspot", str(exc))
-            mock_alert.assert_not_called()
 
-    def test_delete_unauthorized_deletion(self, req_mock, mock_alert):
+    def test_delete_unauthorized_deletion(self, req_mock):
         self._mock_get_vid(req_mock, 200)
         self._mock_delete(req_mock, 401)
         with self.assertRaises(hubspot_api.HubspotException) as exc:
-            HubspotAPI(
-                self.api_key,
-                self.test_region,
-                self.from_address,
-                self.alert_email
-            ).delete_user(self.test_learner)
+            HubspotAPI(self.api_key).delete_user(self.test_learner)
             self.assertIn("Hubspot user deletion failed due to authorized API call", str(exc))
-            mock_alert.assert_not_called()
 
-    def test_delete_vid_not_found(self, req_mock, mock_alert):
+    def test_delete_vid_not_found(self, req_mock):
         self._mock_get_vid(req_mock, 200)
         self._mock_delete(req_mock, 404)
         with self.assertRaises(hubspot_api.HubspotException) as exc:
-            HubspotAPI(
-                self.api_key,
-                self.test_region,
-                self.from_address,
-                self.alert_email
-            ).delete_user(self.test_learner)
+            HubspotAPI(self.api_key).delete_user(self.test_learner)
             self.assertIn("Hubspot user deletion failed because vid doesn't match user", str(exc))
-            mock_alert.assert_not_called()
 
-    def test_delete_server_failure_on_deletion(self, req_mock, mock_alert):
+    def test_delete_server_failure_on_deletion(self, req_mock):
         self._mock_get_vid(req_mock, 200)
         self._mock_delete(req_mock, 500)
         with self.assertRaises(hubspot_api.HubspotException) as exc:
-            HubspotAPI(
-                self.api_key,
-                self.test_region,
-                self.from_address,
-                self.alert_email
-            ).delete_user(self.test_learner)
+            HubspotAPI(self.api_key).delete_user(self.test_learner)
             self.assertIn("Hubspot user deletion failed due to server-side (Hubspot) issues", str(exc))
-            mock_alert.assert_not_called()
 
-    def test_delete_catch_all_on_deletion(self, req_mock, mock_alert):
+    def test_delete_catch_all_on_deletion(self, req_mock):
         self._mock_get_vid(req_mock, 200)
         # Testing 403 as it's not a response type per the Hubspot API docs, so it doesn't have it's own error.
         self._mock_delete(req_mock, 403)
         with self.assertRaises(hubspot_api.HubspotException) as exc:
-            HubspotAPI(
-                self.api_key,
-                self.test_region,
-                self.from_address,
-                self.alert_email
-            ).delete_user(self.test_learner)
+            HubspotAPI(self.api_key).delete_user(self.test_learner)
             self.assertIn("Hubspot user deletion failed due to unknown reasons", str(exc))
-            mock_alert.assert_not_called()


### PR DESCRIPTION
Reverts edx/tubular#450

`ses:SendEmail` failed due to possible missing AWS permissions, reverting to unblock the build until it is resolved