### PR TITLE
Revert "Revert "Upgrade moto > 1.0.0, unpin testing dependencies for …

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,81 @@
+Aarif <MrAarif@outlook.com>
+Aarif <mraarif@outlook.com>
+Adam Blackwell <adam@blackwell.ai>
+Adam Blackwell <adzuci@users.noreply.github.com>
+Adam Butterworth <abutterworth@edx.org>
+Adeel Khan <muhammad.adeel@arbisoft.com>
+Awais Qureshi <awais.qureshi@arbisoft.com>
+Ben Holt <bholt+github@edx.org>
+Bianca Severino <biancasev@gmail.com>
+Bianca Severino <bseverino@edx.org>
+Bill DeRusha <bill.derusha@gmail.com>
+Bill DeRusha <bill@edx.org>
+Brandon Baker <bbaker6225@users.noreply.github.com>
+Brandon Baker <bbaker@edx.org>
+Brian Beggs <bbeggs@edx.org>
+Brian Beggs <macdiesel@gmail.com>
+Brian Beggs <macdiesel@speakeasy.net>
+Brian Mesick <bmesick@edx.org>
+Calen Pennington <cale@edx.org>
+Calen Pennington <calen.pennington@gmail.com>
+Chris Pappas <christopappas@users.noreply.github.com>
+Christie Rice <8483753+crice100@users.noreply.github.com>
+Cory Lee <cl10001123@gmail.com>
+Cory Lee <cory@edx.org>
+Dave Chamberlain <dchamberlain@edx.org>
+Dave St.Germain <dave@st.germa.in>
+Dave St.Germain <dstgermain@edx.org>
+David Ormsbee <dave@edx.org>
+Diana Huang <dkh@edx.org>
+Dillon Dumesnil <ddumesnil@edx.org>
+Dillon Dumesnil <dillon.dumesnil@gmail.com>
+Dillon-Dumesnil <dillon.dumesnil@gmail.com>
+Douglas Hall <dhall@edx.org>
+Elton Carr, II <eltonc@microsoft.com>
+Feanil Patel <feanil@edx.org>
+Fred Smith <derf@edx.org>
+Gregory Martin <greg@edx.org>
+Gregory Martin <yro@users.noreply.github.com>
+Isabel <isabelgk@users.noreply.github.com>
+J Eskew <jeskew@edx.org>
+Jansen Kantor <jkantor@edx.org>
+Jesse Zoldak <zoldak@edx.org>
+John Eskew <jeskew@edx.org>
+Joseph Mulloy <jdmulloy@users.noreply.github.com>
+Joseph Mulloy <jmulloy@edx.org>
+Julia Eskew <jeskew@edx.org>
+Julia Eskew <julia.eskew@edx.org>
+Justin Hynes <jhynes@edx.org>
+Kevin Falcone <kevin@edx.org>
+Kevin Falcone <kevin@jibsheet.com>
+Kyle McCormick <kdmccormick@wpi.edu>
+Luis Moreno <luis.moreno@edunext.co>
+Matt Hughes <mhughes@edx.org>
+Matt Tuchfarber <matt@tuchfarber.com>
+Matt Tuchfarber <mtuchfarber@edx.org>
+Michael Youngstrom <myoungstrom@edx.org>
+Michael Youngstrom <youngstrom.m@husky.neu.edu>
+Mike Dikan <mike.dikan@gmail.com>
+Nadeem Shahzad <nadem.shahzad@gmail.com>
+Nadeem Shahzad <nshahzad@edx.org>
+Nathan Sprenkle <nsprenkle@users.noreply.github.com>
+Renzo Lucioni <renzo@lucioni.xyz>
+Sharon Wang <sharon.ran.wang@gmail.com>
+Simon Chen <schen@edx.org>
+Sofiya Semenova <sofiya@sofiya.io>
+Stu Young <estute@users.noreply.github.com>
+Stuart Young <syoung@edx.org>
+Syed Awais Ali <awaisalisabir@gmail.com>
+Troy Sankey <sankeytms@gmail.com>
+Troy Sankey <tsankey@edx.org>
+Zia Fazal <zia.fazal@arbisoft.com>
+adeel khan <muhammad.adeel@arbisoft.com>
+bmedx <bmesick@edx.org>
+dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+jansenk <jkantor@edx.org>
+nadeemshahzad <nshahzad@edx.org>
+srwang <sharon.ran.wang@gmail.com>
+syed-awais-ali <aali@edx.org>
+syed-awais-ali <awaisalisabir@gmail.com>
+syedimranhassan <45480841+syedimranhassan@users.noreply.github.com>
+syedimranhassan <imran.hassan@arbisoft.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,37 @@
 CHANGES
 =======
 
-* MST-482 - Send email alert upon successful Hubspot deletion
-* ISRE-588 - update javasocketerror raise logic
-* ISRE-587 - update giveup logic
-* Fix tox/pytest
+* pycodestyle, remove unneeded pinning
+* Iterating..
+* Unpin httpretty
+* Use lowest supported python version for dockerfile so that upgrades applied here use the correct version.  Then do a make upgrade
+* Upgrade moto > 1.0.0, unpin testing dependencies for edx\_lint, remove unsupported pytest-pep8 library
+* Revert "Updating pycodestyleversion (#472)"
+* Revert "Removing merge conflict (#473)"
+* Removing merge conflict (#473)
+* Updating pycodestyleversion (#472)
+* Adding deploy script to deploy gocd agents (#461)
+* Adding a tubular pipeline for deploying things with docker instead of legacy agents (#460)
+* replace travis with GHA
+* update make\_plan for click
+* Upgrading from click 6.7 to 7 to fix a collision in gocd20 pipelines that occurs due to a missing separate install of python which causes an unintentional downgrade (#456)
+* Bump cryptography from 2.9.2 to 3.2 in /requirements (#455)
+* Improving the log hygiene for base amis
+* Allow HubspotAPI to send email to marketing upon successful deletion
+* ISRE-588 | check most recent log for java socket error (#453)
+* ISRE-587 | Adding logic to properly raise multiple image exception er… (#452)
+* removed exception
+* Revert "Revert "Add ability to grab focal base image for deployment pipelines""
+* Revert "Add ability to grab focal base image for deployment pipelines"
+* Add ability to grab focal base image for deployment pipelines
+* Catch and retry new\_asg on socket exception. (#446)
+* Removed deprecated future imports (#445)
+* ran 2to3 to remove deprecated imports
+* Add option to disable logging 404s as an error (#444)
+* Log more info on api error for debugging
+* Add license-manager retirement to pipeline
+* Fix pylint complaints
+* Pin pytest to fix test failures
 * Ignore Github Actions Results PSRE-168
 * Ignore internal & secure in recent deployers
 * OEP-18 compliance

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-buster
+FROM python:3.5-buster
 
 WORKDIR /app
 ADD . /app

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,7 +3,7 @@
 atlassian-python-api
 backoff==1.5.0
 boto==2.43.0
-click-log==0.1.8
+click-log
 click>=7.0.0
 cloudflare==2.1.0
 edx-opaque-keys==0.4.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,20 +4,20 @@
 #
 #    make upgrade
 #
-atlassian-python-api==2.0.1  # via -r requirements/base.in
+atlassian-python-api==2.2.0  # via -r requirements/base.in
 authlib==0.15.2           # via simple-salesforce
 backoff==1.5.0            # via -r requirements/base.in
 boto==2.43.0              # via -r requirements/base.in
-cachetools==4.1.1         # via google-auth
-certifi==2020.11.8        # via requests
-cffi==1.14.3              # via cryptography
-chardet==3.0.4            # via requests
-click-log==0.1.8          # via -r requirements/base.in
+cachetools==4.2.0         # via google-auth
+certifi==2020.12.5        # via requests
+cffi==1.14.4              # via cryptography
+chardet==4.0.0            # via requests
+click-log==0.3.2          # via -r requirements/base.in
 click==7.1.2              # via -r requirements/base.in, click-log
 cloudflare==2.1.0         # via -r requirements/base.in
 cryptography==3.2.1       # via authlib
 decorator==4.4.2          # via validators
-deprecated==1.2.10        # via pygithub
+deprecated==1.2.10        # via atlassian-python-api, pygithub
 easydict==1.9             # via yagocd
 edx-opaque-keys==0.4.0    # via -r requirements/base.in
 edx-rest-api-client==1.7.1  # via -r requirements/base.in
@@ -32,7 +32,7 @@ httplib2==0.18.1          # via google-api-python-client, google-auth-httplib2
 idna==2.10                # via requests
 jenkinsapi==0.3.3         # via -r requirements/base.in
 jsonlines==1.2.0          # via cloudflare
-lxml==4.6.1               # via -r requirements/base.in
+lxml==4.6.2               # via -r requirements/base.in
 oauthlib==3.1.0           # via atlassian-python-api, requests-oauthlib
 pbr==5.5.1                # via stevedore
 pyasn1-modules==0.2.8     # via google-auth
@@ -45,7 +45,7 @@ python-dateutil==2.8.1    # via freezegun
 pytz==2016.10             # via -r requirements/base.in, jenkinsapi
 pyyaml==5.1               # via -r requirements/base.in, cloudflare
 requests-oauthlib==1.3.0  # via atlassian-python-api
-requests==2.25.0          # via -r requirements/base.in, atlassian-python-api, cloudflare, jenkinsapi, pygithub, requests-oauthlib, sailthru-client, simple-salesforce, slumber, yagocd
+requests==2.25.1          # via -r requirements/base.in, atlassian-python-api, cloudflare, jenkinsapi, pygithub, requests-oauthlib, sailthru-client, simple-salesforce, slumber, yagocd
 rsa==4.6                  # via google-auth
 sailthru-client==2.3.5    # via -r requirements/base.in
 simple-salesforce==1.10.1  # via -r requirements/base.in
@@ -56,8 +56,8 @@ smmap==3.0.4              # via gitdb
 stevedore==1.32.0         # via edx-opaque-keys
 unicodecsv==0.14.1        # via -r requirements/base.in
 uritemplate==3.0.1        # via google-api-python-client
-urllib3==1.26.1           # via requests
-validators==0.18.1        # via -r requirements/base.in
+urllib3==1.26.2           # via requests
+validators==0.18.2        # via -r requirements/base.in
 wrapt==1.11.2             # via -r requirements/base.in, deprecated
 yagocd==0.4.4             # via -r requirements/base.in
 

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.3.1          # via -r requirements/pip-tools.in
+pip-tools==5.4.0          # via -r requirements/pip-tools.in
 six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,18 +66,18 @@ console_scripts =
 
 [extras]
 test =
-    astroid==2.3.3
-    ddt==1.0.1
+    astroid
+    ddt
     edx_lint
-    httpretty<1.0.0
-    moto==0.4.31
+    httpretty
+    moto>=1.0.0
     mock
-    pylint==2.4.2
-    pep8==1.7.0
+    pylint
     pytest
+    pycodestyle
+    pytest-pycodestyle
     pytest-xdist
     pytest-pylint
-    pytest-pep8
     responses
     requests_mock
     wrapt==1.11.*

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,8 @@ envlist = py{35,38}
 skip_missing_interpreters = True
 
 [testenv]
-deps = pytest < 6
+deps = pytest
 extras=test
 whitelist_externals=pytest
 commands=pytest {posargs:-n auto}
 
-[pytest]
-addopts = --pylint --pep8 --pylint-rcfile=pylintrc
-
-pep8ignore=E501 E402 E131
-pep8maxlinelength=119

--- a/tubular/tests/test_asgard.py
+++ b/tubular/tests/test_asgard.py
@@ -10,7 +10,7 @@ import mock
 import requests_mock
 
 from ddt import ddt, data, unpack
-from moto import mock_ec2, mock_autoscaling, mock_elb
+from moto import mock_ec2_deprecated, mock_autoscaling_deprecated, mock_elb_deprecated
 from moto.ec2.utils import random_ami_id
 from six.moves import urllib, reload_module
 import tubular.asgard as asgard
@@ -839,8 +839,8 @@ class TestAsgard(unittest.TestCase):
         with mock.patch("tubular.ec2.remove_asg_deletion_tag"):
             self.assertRaises(CannotDeleteLastASG, asgard.delete_asg, asg)
 
-    @mock_autoscaling
-    @mock_ec2
+    @mock_autoscaling_deprecated
+    @mock_ec2_deprecated
     @data(*itertools.product(
         ((asgard.ASG_ACTIVATE_URL, asgard.enable_asg), (asgard.ASG_DEACTIVATE_URL, asgard.disable_asg)),
         (True, False)
@@ -906,9 +906,9 @@ class TestAsgard(unittest.TestCase):
         else:
             self.assertRaises(BackendError, test_function, asg)
 
-    @mock_autoscaling
-    @mock_ec2
-    @mock_elb
+    @mock_autoscaling_deprecated
+    @mock_ec2_deprecated
+    @mock_elb_deprecated
     def test_deploy_asg_error_did_not_create_multiple_asgs(self, req_mock):
         """
         Test that new_asg is not called more than the number of asgs that
@@ -946,9 +946,9 @@ class TestAsgard(unittest.TestCase):
             pass
         self.assertEqual(1, counter)  # We fail midway here, so we dont expect additional calls to new_asg
 
-    @mock_autoscaling
-    @mock_ec2
-    @mock_elb
+    @mock_autoscaling_deprecated
+    @mock_ec2_deprecated
+    @mock_elb_deprecated
     def test_deploy_asg_rate_limit_did_not_create_multiple_asgs(self, req_mock):
         """
         Test that new_asg is not called more than the number of asgs that are
@@ -1182,9 +1182,9 @@ class TestAsgard(unittest.TestCase):
                 json=deleted_asg_in_progress(asg),
                 status_code=response_code)
 
-    @mock_autoscaling
-    @mock_ec2
-    @mock_elb
+    @mock_autoscaling_deprecated
+    @mock_ec2_deprecated
+    @mock_elb_deprecated
     def test_deploy_asg_failed(self, req_mock):
         ami_id = self._setup_for_deploy(
             req_mock,
@@ -1192,9 +1192,9 @@ class TestAsgard(unittest.TestCase):
         )
         self.assertRaises(Exception, asgard.deploy, ami_id)
 
-    @mock_autoscaling
-    @mock_ec2
-    @mock_elb
+    @mock_autoscaling_deprecated
+    @mock_ec2_deprecated
+    @mock_elb_deprecated
     def test_deploy_enable_asg_failed(self, req_mock):
         ami_id = self._setup_for_deploy(
             req_mock,
@@ -1203,18 +1203,18 @@ class TestAsgard(unittest.TestCase):
         )
         self.assertRaises(Exception, asgard.deploy, ami_id)
 
-    @mock_autoscaling
-    @mock_ec2
-    @mock_elb
+    @mock_autoscaling_deprecated
+    @mock_ec2_deprecated
+    @mock_elb_deprecated
     def test_deploy_elb_health_failed(self, req_mock):
         ami_id = self._setup_for_deploy(req_mock, COMPLETED_SAMPLE_TASK, COMPLETED_SAMPLE_TASK)
         mock_function = "tubular.ec2.wait_for_healthy_elbs"
         with mock.patch(mock_function, side_effect=Exception("Never became healthy.")):
             self.assertRaises(Exception, asgard.deploy, ami_id)
 
-    @mock_autoscaling
-    @mock_ec2
-    @mock_elb
+    @mock_autoscaling_deprecated
+    @mock_ec2_deprecated
+    @mock_elb_deprecated
     def test_deploy(self, req_mock):
         ami_id = self._setup_for_deploy(req_mock)
 
@@ -1265,9 +1265,9 @@ class TestAsgard(unittest.TestCase):
 
         self.assertEqual(expected_output, asgard.deploy(ami_id))
 
-    @mock_autoscaling
-    @mock_ec2
-    @mock_elb
+    @mock_autoscaling_deprecated
+    @mock_ec2_deprecated
+    @mock_elb_deprecated
     def test_deploy_new_asg_disabled(self, req_mock):
         ami_id = self._setup_for_deploy(req_mock)
         asgs = ["loadtest-edx-edxapp-v058", "loadtest-edx-edxapp-v059",
@@ -1287,9 +1287,9 @@ class TestAsgard(unittest.TestCase):
             )
         self.assertRaises(BackendError, asgard.deploy, ami_id)
 
-    @mock_autoscaling
-    @mock_ec2
-    @mock_elb
+    @mock_autoscaling_deprecated
+    @mock_ec2_deprecated
+    @mock_elb_deprecated
     def test_rollback(self, req_mock):
         ami_id = self._setup_for_deploy(req_mock)
 
@@ -1449,9 +1449,9 @@ class TestAsgard(unittest.TestCase):
             json=VALID_CLUSTER_JSON_INFO
         )
 
-    @mock_autoscaling
-    @mock_ec2
-    @mock_elb
+    @mock_autoscaling_deprecated
+    @mock_ec2_deprecated
+    @mock_elb_deprecated
     def test_rollback_with_failure_and_with_redeploy(self, req_mock):
         self._setup_rollback(req_mock)
 
@@ -1498,9 +1498,9 @@ class TestAsgard(unittest.TestCase):
             expected_output
         )
 
-    @mock_autoscaling
-    @mock_ec2
-    @mock_elb
+    @mock_autoscaling_deprecated
+    @mock_ec2_deprecated
+    @mock_elb_deprecated
     def test_rollback_with_failure_and_without_redeploy(self, req_mock):
         self._setup_rollback(req_mock)
 
@@ -1550,9 +1550,9 @@ class TestAsgard(unittest.TestCase):
             expected_output
         )
 
-    @mock_autoscaling
-    @mock_ec2
-    @mock_elb
+    @mock_autoscaling_deprecated
+    @mock_ec2_deprecated
+    @mock_elb_deprecated
     @mock.patch('boto.ec2.autoscale.AutoScaleConnection.delete_tags', lambda *args: None)
     def test_rollback_with_failure_and_asgs_tagged_for_deletion(self, req_mock):
         self._setup_rollback(req_mock)
@@ -1604,9 +1604,9 @@ class TestAsgard(unittest.TestCase):
             expected_output
         )
 
-    @mock_autoscaling
-    @mock_ec2
-    @mock_elb
+    @mock_autoscaling_deprecated
+    @mock_ec2_deprecated
+    @mock_elb_deprecated
     @mock.patch('boto.ec2.autoscale.AutoScaleConnection.delete_tags', lambda *args: None)
     def test_rollback_asg_does_not_exist(self, req_mock):
         self._setup_rollback_deleted(req_mock)


### PR DESCRIPTION
…edx_lint (#480)" (#484)"

This original revert did not fix the error as we thought it would, so putting it back.

This reverts commit d5cd2c38198b3250b6a3378ccdac7ae19d6b5111.