### PR TITLE
AA-595: Add script to delete Braze user information

### DIFF
--- a/tubular/braze_api.py
+++ b/tubular/braze_api.py
@@ -1,0 +1,85 @@
+"""
+Helper API classes for calling Braze APIs.
+"""
+import logging
+import os
+
+import backoff
+import requests
+
+LOG = logging.getLogger(__name__)
+MAX_ATTEMPTS = int(os.environ.get('RETRY_BRAZE_MAX_ATTEMPTS', 5))
+
+
+class BrazeException(Exception):
+    pass
+
+
+class BrazeRecoverableException(BrazeException):
+    pass
+
+
+class BrazeApi:
+    """
+    Braze API client used to make calls to Braze
+    """
+
+    def __init__(self, braze_api_key, braze_instance):
+        self.api_key = braze_api_key
+
+        # https://www.braze.com/docs/api/basics/#endpoints
+        self.base_url = 'https://rest.{instance}.braze.com'.format(instance=braze_instance)
+
+    def auth_headers(self):
+        """Returns authorization headers suitable for passing to the requests library"""
+        return {
+            'Authorization': 'Bearer ' + self.api_key,
+        }
+
+    @staticmethod
+    def get_error_message(response):
+        """Returns a string suitable for logging"""
+        try:
+            json = response.json()
+        except ValueError:
+            json = {}
+
+        # https://www.braze.com/docs/api/errors
+        message = json.get('message')
+
+        return message or response.reason
+
+    def process_response(self, response, action):
+        """Log response status and raise an error as needed"""
+        if response.ok:
+            LOG.info('Braze {action} succeeded'.format(action=action))
+            return
+
+        # We have some sort of error. Parse it, log it, and retry as needed.
+        error_msg = 'Braze {action} failed due to {msg}'.format(action=action, msg=self.get_error_message(response))
+        LOG.error(error_msg)
+
+        if response.status_code == 429 or 500 <= response.status_code < 600:
+            raise BrazeRecoverableException(error_msg)
+        else:
+            raise BrazeException(error_msg)
+
+    @backoff.on_exception(
+        backoff.expo,
+        BrazeRecoverableException,
+        max_tries=MAX_ATTEMPTS,
+    )
+    def delete_user(self, learner):
+        """
+        Delete a learner from Braze.
+        """
+        # https://www.braze.com/docs/help/gdpr_compliance/#the-right-to-erasure
+        # https://www.braze.com/docs/api/endpoints/user_data/post_user_delete
+        response = requests.post(
+            self.base_url + '/users/delete',
+            headers=self.auth_headers(),
+            json={
+                'external_ids': [learner['user']['id']],  # Braze external ids are LMS user ids
+            },
+        )
+        self.process_response(response, 'user deletion')

--- a/tubular/scripts/helpers.py
+++ b/tubular/scripts/helpers.py
@@ -23,6 +23,7 @@ sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from tubular.edx_api import CredentialsApi, DemographicsApi, EcommerceApi, LicenseManagerApi, \
     LmsApi  # pylint: disable=wrong-import-position
+from tubular.braze_api import BrazeApi  # pylint: disable=wrong-import-position
 from tubular.segment_api import SegmentApi  # pylint: disable=wrong-import-position
 from tubular.sailthru_api import SailthruApi  # pylint: disable=wrong-import-position
 from tubular.salesforce_api import SalesforceApi  # pylint: disable=wrong-import-position
@@ -155,6 +156,8 @@ def _setup_all_apis_or_exit(fail_func, fail_code, config):
         license_manager_base_url = config['base_urls'].get('license_manager', None)
         client_id = config['client_id']
         client_secret = config['client_secret']
+        braze_api_key = config.get('braze_api_key', None)
+        braze_instance = config.get('braze_instance', None)
         sailthru_key = config.get('sailthru_key', None)
         sailthru_secret = config.get('sailthru_secret', None)
         salesforce_user = config.get('salesforce_user', None)
@@ -171,6 +174,7 @@ def _setup_all_apis_or_exit(fail_func, fail_code, config):
 
         for state in config['retirement_pipeline']:
             for service, service_url in (
+                    ('BRAZE', braze_api_key),
                     ('ECOMMERCE', ecommerce_base_url),
                     ('CREDENTIALS', credentials_base_url),
                     ('SEGMENT', segment_base_url),
@@ -182,6 +186,12 @@ def _setup_all_apis_or_exit(fail_func, fail_code, config):
                     fail_func(fail_code, 'Service URL is not configured, but required for state {}'.format(state))
 
         config['LMS'] = LmsApi(lms_base_url, lms_base_url, client_id, client_secret)
+
+        if braze_api_key:
+            config['BRAZE'] = BrazeApi(
+                braze_api_key,
+                braze_instance,
+            )
 
         if sailthru_key:
             config['SAILTHRU'] = SailthruApi(sailthru_key, sailthru_secret)

--- a/tubular/tests/test_braze.py
+++ b/tubular/tests/test_braze.py
@@ -1,0 +1,67 @@
+"""
+Tests for the Braze API functionality
+"""
+import ddt
+import os
+import logging
+import unittest
+from unittest import mock
+
+import requests_mock
+
+os.environ['RETRY_BRAZE_MAX_ATTEMPTS'] = '2'
+from tubular.braze_api import BrazeApi, BrazeException, BrazeRecoverableException
+
+
+@ddt.ddt
+@requests_mock.Mocker()
+class TestBraze(unittest.TestCase):
+    """
+    Class containing tests of all code interacting with Braze.
+    """
+    def setUp(self):
+        super().setUp()
+        self.learner = {'user': {'id': 1234}}
+        self.braze = BrazeApi('test-key', 'test-instance')
+
+    def _mock_delete(self, req_mock, status_code, message=None):
+        req_mock.post(
+            'https://rest.test-instance.braze.com/users/delete',
+            request_headers={'Authorization': 'Bearer test-key'},
+            json={'message': message} if message else {},
+            status_code=status_code
+        )
+
+    def test_delete_happy_path(self, req_mock):
+        self._mock_delete(req_mock, 200)
+
+        logger = logging.getLogger('tubular.braze_api')
+        with mock.patch.object(logger, 'info') as mock_info:
+            self.braze.delete_user(self.learner)
+
+        self.assertEqual(mock_info.call_args, [('Braze user deletion succeeded',)])
+
+        self.assertEqual(len(req_mock.request_history), 1)
+        request = req_mock.request_history[0]
+        self.assertEqual(request.json(), {'external_ids': [1234]})
+
+    def test_delete_fatal_error(self, req_mock):
+        self._mock_delete(req_mock, 404, message='Test Error Message')
+
+        logger = logging.getLogger('tubular.braze_api')
+        with mock.patch.object(logger, 'error') as mock_error:
+            with self.assertRaises(BrazeException) as exc:
+                self.braze.delete_user(self.learner)
+
+        error = 'Braze user deletion failed due to Test Error Message'
+        self.assertEqual(mock_error.call_args, [(error,)])
+        self.assertEqual(str(exc.exception), error)
+
+    @ddt.data(429, 500)
+    def test_delete_recoverable_error(self, status_code, req_mock):
+        self._mock_delete(req_mock, status_code)
+
+        with self.assertRaises(BrazeRecoverableException):
+            self.braze.delete_user(self.learner)
+
+        self.assertEqual(len(req_mock.request_history), 2)


### PR DESCRIPTION
Adds two new config variables:
- braze_api_key: a REST API key from Braze with users.delete access
- braze_instance: a Braze instance key like iad-01

And sets the BRAZE service variable & 'delete_user' method, for use in retirement pipelines.