### PR TITLE
Jkantor/escape salesforce query

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 CHANGES
 =======
 
+* escape salesforce api queries
 * Revert "Revert "Upgrade moto > 1.0.0, unpin testing dependencies for edx\_lint (#480)" (#484)" (#485)
 * Revert "Upgrade moto > 1.0.0, unpin testing dependencies for edx\_lint (#480)" (#484)
 * Remove calls to method that does not exist (#483)

--- a/tubular/salesforce_api.py
+++ b/tubular/salesforce_api.py
@@ -5,7 +5,7 @@ import os
 import logging
 import backoff
 from requests.exceptions import ConnectionError as RequestsConnectionError
-from simple_salesforce import Salesforce
+from simple_salesforce import Salesforce, format_soql
 
 LOG = logging.getLogger(__name__)
 
@@ -61,8 +61,7 @@ class SalesforceApi:
         Given an id, query for a Lead with that email
         Returns a list of ids tht have that email or None if none are found
         """
-        query_string = "SELECT Id FROM Lead WHERE Email='{email}'"
-        id_query = self._sf.query(query_string.format(email=email))
+        id_query = self._sf.query(format_soql("SELECT Id FROM Lead WHERE Email = {email}", email=email))
         total_size = int(id_query['totalSize'])
         if total_size == 0:
             return None
@@ -83,8 +82,7 @@ class SalesforceApi:
         or None if no user is found
         Used to get a the user id of the user we will assign the retirement task to
         """
-        query_string = "SELECT Id FROM User WHERE Username='{username}'"
-        id_query = self._sf.query(query_string.format(username=username))
+        id_query = self._sf.query(format_soql("SELECT Id FROM User WHERE Username = {username}", username=username))
         total_size = int(id_query['totalSize'])
         if total_size == 0:
             return None

--- a/tubular/tests/test_salesforce.py
+++ b/tubular/tests/test_salesforce.py
@@ -58,6 +58,27 @@ def test_retire_get_id_error(test_learner):  # pylint: disable=redefined-outer-n
             with pytest.raises(SalesforceError):
                 api.retire_learner(test_learner)
 
+# pylint: disable=protected-access
+def test_escape_email():
+    with mock.patch('tubular.salesforce_api.Salesforce'):
+        api = make_api()
+        mock_response = {'totalSize': 0, 'records': []}
+        api._sf.query.return_value = mock_response
+        api.get_lead_ids_by_email("Robert'); DROP TABLE students;--")
+        api._sf.query.assert_called_with(
+            "SELECT Id FROM Lead WHERE Email = 'Robert\\'); DROP TABLE students;--'"
+        )
+
+# pylint: disable=protected-access
+def test_escape_username():
+    with mock.patch('tubular.salesforce_api.Salesforce'):
+        api = make_api()
+        mock_response = {'totalSize': 0, 'records': []}
+        api._sf.query.return_value = mock_response
+        api.get_user_id("Robert'); DROP TABLE students;--")
+        api._sf.query.assert_called_with(
+            "SELECT Id FROM User WHERE Username = 'Robert\\'); DROP TABLE students;--'"
+        )
 
 def test_retire_learner_not_found(test_learner, caplog):  # pylint: disable=redefined-outer-name
     caplog.set_level(logging.INFO)


### PR DESCRIPTION
- Add query variable escaping to the Salesforce queries made in the `get_lead_ids_by_email` and `get_user_id` API functions