### PR TITLE
Added support for specifying multiple partners.

### DIFF
--- a/tubular/scripts/helpers.py
+++ b/tubular/scripts/helpers.py
@@ -110,7 +110,7 @@ def _config_with_drive_or_exit(fail_func, config_fail_code, google_fail_code, co
         # they are using the same characters. Otherwise accented characters will not match.
         for org in config['org_partner_mapping']:
             partner = config['org_partner_mapping'][org]
-            config['org_partner_mapping'][org] = unicodedata.normalize('NFKC', text_type(partner))
+            config['org_partner_mapping'][org] = [unicodedata.normalize('NFKC', text_type(partner)) for partner in config['org_partner_mapping'][org]]
     except Exception as exc:  # pylint: disable=broad-except
         fail_func(config_fail_code, 'Failed to read config file {}'.format(config_file), exc)
 

--- a/tubular/scripts/retirement_partner_report.py
+++ b/tubular/scripts/retirement_partner_report.py
@@ -134,37 +134,38 @@ def _get_orgs_and_learners_or_exit(config):
             # Create a list of orgs who should be notified about this user
             if ORGS_KEY in learner:
                 for org_name in learner[ORGS_KEY]:
-                    reporting_org_name = config['org_partner_mapping'][org_name]
-                    _add_reporting_org(orgs, reporting_org_name, DEFAULT_FIELD_HEADINGS, learner)
+                    reporting_org_names = config['org_partner_mapping'][org_name]
+                    _add_reporting_org(orgs, reporting_org_names, DEFAULT_FIELD_HEADINGS, learner)
 
             # Check for orgs with custom fields
             if ORGS_CONFIG_KEY in learner:
                 for org_config in learner[ORGS_CONFIG_KEY]:
                     org_name = org_config[ORGS_CONFIG_ORG_KEY]
                     org_headings = org_config[ORGS_CONFIG_FIELD_HEADINGS_KEY]
-                    reporting_org_name = config['org_partner_mapping'][org_name]
-                    _add_reporting_org(orgs, reporting_org_name, org_headings, learner)
+                    reporting_org_names = config['org_partner_mapping'][org_name]
+                    _add_reporting_org(orgs, reporting_org_names, org_headings, learner)
 
         return orgs, usernames
     except Exception as exc:  # pylint: disable=broad-except
         FAIL_EXCEPTION(ERR_FETCHING_LEARNERS, 'Unexpected exception occurred!', exc)
 
 
-def _add_reporting_org(orgs, org_name, org_headings, learner):
+def _add_reporting_org(orgs, org_names, org_headings, learner):
     """
     Add the learner to the org
     """
-    # Create the org, if necessary
-    orgs[org_name] = orgs.get(
-        org_name,
-        {
-            ORGS_CONFIG_FIELD_HEADINGS_KEY: org_headings,
-            ORGS_CONFIG_LEARNERS_KEY: []
-        }
-    )
+    for org_name in org_names:
+        # Create the org, if necessary
+        orgs[org_name] = orgs.get(
+            org_name,
+            {
+                ORGS_CONFIG_FIELD_HEADINGS_KEY: org_headings,
+                ORGS_CONFIG_LEARNERS_KEY: []
+            }
+        )
 
-    # Add the learner to the list of learners in the org
-    orgs[org_name][ORGS_CONFIG_LEARNERS_KEY].append(learner)
+        # Add the learner to the list of learners in the org
+        orgs[org_name][ORGS_CONFIG_LEARNERS_KEY].append(learner)
 
 
 def _generate_report_files_or_exit(config, report_data, output_dir):

--- a/tubular/tests/retirement_helpers.py
+++ b/tubular/tests/retirement_helpers.py
@@ -21,9 +21,9 @@ TEST_RETIREMENT_QUEUE_STATES = ['PENDING'] + TEST_RETIREMENT_END_STATES
 
 FAKE_ORGS = {
     # Make sure unicode names, as they should come in from the yaml config, work
-    'org1': unicodedata.normalize('NFKC', u'TéstX'),
-    'org2': 'Org2X',
-    'org3': 'Org3X',
+    'org1': [unicodedata.normalize('NFKC', u'TéstX')],
+    'org2': ['Org2X'],
+    'org3': ['Org3X', 'Org4X'],
 }
 
 TEST_PLATFORM_NAME = 'fakename'
@@ -32,6 +32,13 @@ TEST_DENIED_NOTIFICATION_DOMAINS = {
     '@edx.org',
     '@partner-reporting-automation.iam.gserviceaccount.com',
 }
+
+def flatten_partner_list(partner_list):
+    """
+    Flattens a list of lists into a list.
+    [["Org1X"], ["Org2X"], ["Org3X", "Org4X"]] => ["Org1X", "Org2X", "Org3X", "Org4X"]
+    """
+    return [partner for sublist in partner_list for partner in sublist]
 
 
 def fake_config_file(f, orgs=None, fetch_ecom_segment_id=False):


### PR DESCRIPTION
https://openedx.atlassian.net/browse/DENG-91
Going forward we will be changing `org_partner_mapping` in user-retirement-secure config to have all the partners as a list. 
Currently we specify the mapping like this:
```
org_partner_mapping:
  AA: edX
  BA: edX
```
Going forward it will be a list:

```
org_partner_mapping:
  AA:
    - edX
  BA:
    - edX
    - BaX
```
