### PR TITLE
Revert "Merge pull request #509 from edx/aali/PSRE-594_no_comments_on_closed_prs"

### DIFF
--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -1011,16 +1011,13 @@ class GitHubAPI:
                     result = False
             return result
 
-        query = "state:closed"
-        closed_pr = self.search_issues(query, 'pr', '', '', '')
-
         if not isinstance(pull_request, PullRequest):
             try:
                 pull_request = self.github_repo.get_pull(pull_request)
             except UnknownObjectException:
                 raise InvalidPullRequestError('PR #{} does not exist'.format(pull_request))
 
-        if force_message or _not_duplicate(pull_request.get_issue_comments(), message_filter) and not closed_pr:
+        if force_message or _not_duplicate(pull_request.get_issue_comments(), message_filter):
             return pull_request.create_issue_comment(message)
         else:
             return None


### PR DESCRIPTION
This reverts commit 7e6f4145a1bb0934d6d42b0a38d017b4cccce0d0, reversing
changes made to 8c13d4d73c3cd2664505fd24c2b72d413c8621ce.

I am reverting this these changes resulted in no status updates in edx-platform's PRs on deploy. 

None of edx-platform's PRs have gotten any updates since this code merged with master on monday.

I suspect the code does not correctly differentiate between merged PRs and closed PRs.