### PR TITLE
fix: switch send_email to use boto3

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.5', '3.8']
+        python-version: ['3.7', '3.8']
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-buster
+FROM python:3.8-buster
 
 WORKDIR /app
 ADD . /app

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test:
 	tox
 
 # Define PIP_COMPILE_OPTS=-v to get more information during make upgrade.
-PIP_COMPILE = pip-compile --no-emit-trusted-host --no-index --rebuild --upgrade  $(PIP_COMPILE_OPTS)
+PIP_COMPILE = pip-compile --no-emit-trusted-host --rebuild --upgrade  $(PIP_COMPILE_OPTS)
 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade:

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,6 +3,7 @@
 atlassian-python-api
 backoff==1.5.0
 boto==2.43.0
+boto3
 click-log
 click>=7.0.0
 cloudflare==2.1.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,8 +10,14 @@ authlib==0.15.3
     # via simple-salesforce
 backoff==1.5.0
     # via -r requirements/base.in
+boto3==1.17.53
+    # via -r requirements/base.in
 boto==2.43.0
     # via -r requirements/base.in
+botocore==1.20.53
+    # via
+    #   boto3
+    #   s3transfer
 cachetools==4.2.1
     # via google-auth
 certifi==2020.12.5
@@ -71,6 +77,10 @@ idna==2.10
     # via requests
 jenkinsapi==0.3.3
     # via -r requirements/base.in
+jmespath==0.10.0
+    # via
+    #   boto3
+    #   botocore
 jsonlines==2.0.0
     # via cloudflare
 kubernetes==12.0.1
@@ -105,6 +115,7 @@ pyparsing==2.4.7
     # via httplib2
 python-dateutil==2.8.1
     # via
+    #   botocore
     #   freezegun
     #   kubernetes
 pytz==2016.10
@@ -135,6 +146,8 @@ requests==2.25.1
     #   yagocd
 rsa==4.7.2
     # via google-auth
+s3transfer==0.3.7
+    # via boto3
 sailthru-client==2.3.5
     # via -r requirements/base.in
 simple-salesforce==1.11.1
@@ -168,6 +181,7 @@ uritemplate==3.0.1
     # via google-api-python-client
 urllib3==1.26.4
     # via
+    #   botocore
     #   kubernetes
     #   requests
 validators==0.18.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,65 +4,182 @@
 #
 #    make upgrade
 #
-atlassian-python-api==3.8.0  # via -r requirements/base.in
-authlib==0.15.3           # via simple-salesforce
-backoff==1.5.0            # via -r requirements/base.in
-boto==2.43.0              # via -r requirements/base.in
-cachetools==4.2.1         # via google-auth
-certifi==2020.12.5        # via kubernetes, requests
-cffi==1.14.5              # via cryptography
-chardet==4.0.0            # via requests
-click-log==0.3.2          # via -r requirements/base.in
-click==7.1.2              # via -r requirements/base.in, click-log
-cloudflare==2.1.0         # via -r requirements/base.in
-cryptography==3.4.7       # via authlib
-decorator==5.0.5          # via validators
-deprecated==1.2.12        # via atlassian-python-api, pygithub
-easydict==1.9             # via yagocd
-edx-opaque-keys==0.4.0    # via -r requirements/base.in
-edx-rest-api-client==1.7.1  # via -r requirements/base.in
-freezegun==0.3.8          # via -r requirements/base.in
-future==0.16.0            # via -r requirements/base.in, cloudflare
-gitdb==4.0.7              # via gitpython
-gitpython==3.1.14         # via -r requirements/base.in
-google-api-python-client==1.7.3  # via -r requirements/base.in
-google-auth-httplib2==0.1.0  # via google-api-python-client
-google-auth==1.28.0       # via google-api-python-client, google-auth-httplib2, kubernetes
-httplib2==0.19.1          # via google-api-python-client, google-auth-httplib2
-idna==2.10                # via requests
-jenkinsapi==0.3.3         # via -r requirements/base.in
-jsonlines==2.0.0          # via cloudflare
-kubernetes==12.0.1        # via -r requirements/base.in
-lxml==4.6.3               # via -r requirements/base.in
-oauthlib==3.1.0           # via atlassian-python-api, requests-oauthlib
-pbr==5.5.1                # via stevedore
-pyasn1-modules==0.2.8     # via google-auth
-pyasn1==0.4.8             # via pyasn1-modules, rsa
-pycparser==2.20           # via cffi
-pygithub==1.43.8          # via -r requirements/base.in
-pyjwt==1.7.1              # via edx-rest-api-client, pygithub
-pymongo==3.5.1            # via -r requirements/base.in, edx-opaque-keys
-pyparsing==2.4.7          # via httplib2
-python-dateutil==2.8.1    # via freezegun, kubernetes
-pytz==2016.10             # via -r requirements/base.in, jenkinsapi
-pyyaml==5.1               # via -r requirements/base.in, cloudflare, kubernetes
-requests-oauthlib==1.3.0  # via atlassian-python-api, kubernetes
-requests==2.25.1          # via -r requirements/base.in, atlassian-python-api, cloudflare, jenkinsapi, kubernetes, pygithub, requests-oauthlib, sailthru-client, simple-salesforce, slumber, yagocd
-rsa==4.7.2                # via google-auth
-sailthru-client==2.3.5    # via -r requirements/base.in
-simple-salesforce==1.11.1  # via -r requirements/base.in
-simplejson==3.17.2        # via sailthru-client
-six==1.15.0               # via -r requirements/base.in, atlassian-python-api, edx-opaque-keys, freezegun, google-api-python-client, google-auth, google-auth-httplib2, kubernetes, python-dateutil, stevedore, validators, websocket-client, yagocd
-slumber==0.7.1            # via edx-rest-api-client
-smmap==4.0.0              # via gitdb
-stevedore==1.32.0         # via edx-opaque-keys
-unicodecsv==0.14.1        # via -r requirements/base.in
-uritemplate==3.0.1        # via google-api-python-client
-urllib3==1.26.4           # via kubernetes, requests
-validators==0.18.2        # via -r requirements/base.in
-websocket-client==0.58.0  # via kubernetes
-wrapt==1.11.2             # via -r requirements/base.in, deprecated
-yagocd==0.4.4             # via -r requirements/base.in
+atlassian-python-api==3.8.0
+    # via -r requirements/base.in
+authlib==0.15.3
+    # via simple-salesforce
+backoff==1.5.0
+    # via -r requirements/base.in
+boto==2.43.0
+    # via -r requirements/base.in
+cachetools==4.2.1
+    # via google-auth
+certifi==2020.12.5
+    # via
+    #   kubernetes
+    #   requests
+cffi==1.14.5
+    # via cryptography
+chardet==4.0.0
+    # via requests
+click-log==0.3.2
+    # via -r requirements/base.in
+click==7.1.2
+    # via
+    #   -r requirements/base.in
+    #   click-log
+cloudflare==2.1.0
+    # via -r requirements/base.in
+cryptography==3.4.7
+    # via authlib
+decorator==5.0.7
+    # via validators
+deprecated==1.2.12
+    # via
+    #   atlassian-python-api
+    #   pygithub
+easydict==1.9
+    # via yagocd
+edx-opaque-keys==0.4.0
+    # via -r requirements/base.in
+edx-rest-api-client==1.7.1
+    # via -r requirements/base.in
+freezegun==0.3.8
+    # via -r requirements/base.in
+future==0.16.0
+    # via
+    #   -r requirements/base.in
+    #   cloudflare
+gitdb==4.0.7
+    # via gitpython
+gitpython==3.1.14
+    # via -r requirements/base.in
+google-api-python-client==1.7.3
+    # via -r requirements/base.in
+google-auth-httplib2==0.1.0
+    # via google-api-python-client
+google-auth==1.29.0
+    # via
+    #   google-api-python-client
+    #   google-auth-httplib2
+    #   kubernetes
+httplib2==0.19.1
+    # via
+    #   google-api-python-client
+    #   google-auth-httplib2
+idna==2.10
+    # via requests
+jenkinsapi==0.3.3
+    # via -r requirements/base.in
+jsonlines==2.0.0
+    # via cloudflare
+kubernetes==12.0.1
+    # via -r requirements/base.in
+lxml==4.6.3
+    # via -r requirements/base.in
+oauthlib==3.1.0
+    # via
+    #   atlassian-python-api
+    #   requests-oauthlib
+pbr==5.5.1
+    # via stevedore
+pyasn1-modules==0.2.8
+    # via google-auth
+pyasn1==0.4.8
+    # via
+    #   pyasn1-modules
+    #   rsa
+pycparser==2.20
+    # via cffi
+pygithub==1.43.8
+    # via -r requirements/base.in
+pyjwt==1.7.1
+    # via
+    #   edx-rest-api-client
+    #   pygithub
+pymongo==3.5.1
+    # via
+    #   -r requirements/base.in
+    #   edx-opaque-keys
+pyparsing==2.4.7
+    # via httplib2
+python-dateutil==2.8.1
+    # via
+    #   freezegun
+    #   kubernetes
+pytz==2016.10
+    # via
+    #   -r requirements/base.in
+    #   jenkinsapi
+pyyaml==5.1
+    # via
+    #   -r requirements/base.in
+    #   cloudflare
+    #   kubernetes
+requests-oauthlib==1.3.0
+    # via
+    #   atlassian-python-api
+    #   kubernetes
+requests==2.25.1
+    # via
+    #   -r requirements/base.in
+    #   atlassian-python-api
+    #   cloudflare
+    #   jenkinsapi
+    #   kubernetes
+    #   pygithub
+    #   requests-oauthlib
+    #   sailthru-client
+    #   simple-salesforce
+    #   slumber
+    #   yagocd
+rsa==4.7.2
+    # via google-auth
+sailthru-client==2.3.5
+    # via -r requirements/base.in
+simple-salesforce==1.11.1
+    # via -r requirements/base.in
+simplejson==3.17.2
+    # via sailthru-client
+six==1.15.0
+    # via
+    #   -r requirements/base.in
+    #   atlassian-python-api
+    #   edx-opaque-keys
+    #   freezegun
+    #   google-api-python-client
+    #   google-auth
+    #   google-auth-httplib2
+    #   kubernetes
+    #   python-dateutil
+    #   stevedore
+    #   validators
+    #   websocket-client
+    #   yagocd
+slumber==0.7.1
+    # via edx-rest-api-client
+smmap==4.0.0
+    # via gitdb
+stevedore==1.32.0
+    # via edx-opaque-keys
+unicodecsv==0.14.1
+    # via -r requirements/base.in
+uritemplate==3.0.1
+    # via google-api-python-client
+urllib3==1.26.4
+    # via
+    #   kubernetes
+    #   requests
+validators==0.18.2
+    # via -r requirements/base.in
+websocket-client==0.58.0
+    # via kubernetes
+wrapt==1.11.2
+    # via
+    #   -r requirements/base.in
+    #   deprecated
+yagocd==0.4.4
+    # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,13 +4,14 @@
 #
 #    make upgrade
 #
-click==7.1.2              # via pip-tools
-importlib-metadata==3.10.0  # via pep517
-pep517==0.10.0            # via pip-tools
-pip-tools==6.0.1          # via -r requirements/pip-tools.in
-toml==0.10.2              # via pep517
-typing-extensions==3.7.4.3  # via importlib-metadata
-zipp==3.4.1               # via importlib-metadata, pep517
+click==7.1.2
+    # via pip-tools
+pep517==0.10.0
+    # via pip-tools
+pip-tools==6.1.0
+    # via -r requirements/pip-tools.in
+toml==0.10.2
+    # via pep517
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = tubular
 description = Continuous Delivery scripts for pipeline evaluation
 classifier =
     Programming Language :: Python 3
-    Programming Language :: Python 3.5
+    Programming Language :: Python 3.7
     Programming Language :: Python 3.8
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@ from setuptools import setup
 
 setup(
     setup_requires=[u'pbr>=1.9', u'setuptools>=17.1'],
-    python_requires=">=3.5, <3.9",
+    python_requires=">=3.7, <3.9",
     pbr=True,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,38}
+envlist = py{37,38}
 skip_missing_interpreters = True
 
 [testenv]

--- a/tubular/tubular_email.py
+++ b/tubular/tubular_email.py
@@ -4,7 +4,7 @@ Convenience functions using boto and AWS SES to send email.
 
 import logging
 import backoff
-from boto import ses
+import boto3
 from tubular.exception import BackendError
 from tubular.utils import envvar_get_int
 
@@ -39,10 +39,22 @@ def _send_email_with_retry(ses_conn,
     Send email, retrying upon exception.
     """
     ses_conn.send_email(
-        source=from_address,
-        subject=subject,
-        body=body,
-        to_addresses=to_addresses
+        Source=from_address,
+        Message={
+            "Body": {
+                "Text": {
+                    "Charset": "UTF-8",
+                    "Data": body,
+                },
+            },
+            "Subject": {
+                "Charset": "UTF-8",
+                "Data": subject,
+            },
+        },
+        Destination={
+            "ToAddresses": to_addresses,
+        },
     )
 
 
@@ -61,7 +73,7 @@ def send_email(aws_region,
         subject (str): Subject to use in the email.
         body (str): Body to use in the email - text format.
     """
-    ses_conn = ses.connect_to_region(aws_region)
+    ses_conn = boto3.client("ses", region_name=aws_region)
     _send_email_with_retry(
         ses_conn,
         from_address,


### PR DESCRIPTION
```
commit 96d5f46ade46f49a2a725e7b5bbb29e6b088cdd9
Author: Troy Sankey <tsankey@edx.org>
Date:   Fri Apr 16 17:40:09 2021 -0400

    chore: update CI to test python 3.7, 3.8, remove 3.5
    
    Python 3.5 was *already* not compatible with this repo since there were
    several packages in requirements/base.txt that were not even installable
    with 3.5.  Also, I specifically opted to skip python 3.6 because even
    Ubuntu oldstable (18.04) ships python 3.8 via standard bionic
    repositories.

commit cd3c13ac81b3a44a33fbe3d1776ae749a396d1e9
Author: Troy Sankey <tsankey@edx.org>
Date:   Fri Apr 16 16:36:08 2021 -0400

    fix: switch send_email to use boto3
    
    boto2 send_email() outright doesn't work anymore, and the package is
    totally out of maintenance now so our only option is to migrate to
    boto3.  This was brought to our attention when it started breaking the
    user retirement pipeline (the hubspot stage which sends a notification
    email internally).  The AWS error message was clear that we must upgrade
    our API client (boto2).
    
    I also ran make upgrade.

commit 1552c897ad6d6423bd50bd1053fb95ce11b7d303
Author: Troy Sankey <tsankey@edx.org>
Date:   Fri Apr 16 16:32:32 2021 -0400

    fix: remove --no-index from pip-compile call, and run make upgrade
    
    This option doesn't exist, plain and simple.  I'm not sure how it made
    it's way into the Makefile to begin with.  It breaks make upgrade, so it
    has to go!
```