### PR TITLE
fix: re-add python 3.6 support (for GoCD)

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8']
+        python-version: ['3.6', '3.7', '3.8']
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ name = tubular
 description = Continuous Delivery scripts for pipeline evaluation
 classifier =
     Programming Language :: Python 3
+    Programming Language :: Python 3.6
     Programming Language :: Python 3.7
     Programming Language :: Python 3.8
 

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@ from setuptools import setup
 
 setup(
     setup_requires=[u'pbr>=1.9', u'setuptools>=17.1'],
-    python_requires=">=3.7, <3.9",
+    python_requires=">=3.6, <3.9",
     pbr=True,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38}
+envlist = py{36,37,38}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Turns out python 3.6 was still in our stack somewhere.