### PR TITLE
Enable release tagging

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -7,3 +7,5 @@ nick: tubul
 oeps:
   oep-7: true     # Python 3.6
   oep-18: true
+openedx-release:
+  ref: master


### PR DESCRIPTION
This pull request is about enabling Open edX release tagging.
Since the `configuration` [playbooks](https://github.com/edx/configuration/blob/3562b01001067ccb081df0a26001d58b69ff970c/playbooks/roles/user_retirement_pipeline/defaults/main.yml#L41) are using `master` by default we are now seeing some issues while installing Juniper on Ubuntu 16.04.

One of the recent commits in the `tubular` repository bumped some dependencies that are not available for Python 3.5 which is the Python version used by Ubuntu 16.04. Anyway, this pull request doesn't fix this issue but will allow us to update the `configuration` playbook to have better control over which version of `tubular` to deploy.

Juniper Periodic builds mailing list: https://groups.google.com/g/open-edx-btr-notifications/c/v3vGl4IJ8e8/m/KmntUwNSCgAJ

**Jira tickets**

- [FAL-1855](https://tasks.opencraft.com/browse/FAL-1855)

cc @nedbat 