### PR TITLE
fix: wrap frontend config override values in quotes

### DIFF
--- a/tubular/scripts/frontend_build.py
+++ b/tubular/scripts/frontend_build.py
@@ -64,17 +64,12 @@ def frontend_build(common_config_file, env_config_file, app_name, version_file):
     builder.install_requirements()
     app_config = builder.get_app_config()
     env_vars = [
-        "{}={}".format(k, ensure_wrapped_in_quotes(v))
+        f"{k}={ensure_wrapped_in_quotes(v)}"
         for k, v in app_config.items()
     ]
-    builder.build_app(env_vars, 'Could not run `npm run build` for app {}.'.format(app_name))
+    builder.build_app(env_vars, f'Could not run `npm run build` for app {app_name}.')
     builder.create_version_file()
-    LOG(
-        'Frontend app {} built successfully with config file {}.'.format(
-            app_name,
-            env_config_file,
-        )
-    )
+    LOG(f'Frontend app {app_name} built successfully with config file {env_config_file}.')
 
 
 def ensure_wrapped_in_quotes(value: str) -> str:
@@ -100,7 +95,7 @@ def ensure_wrapped_in_quotes(value: str) -> str:
     elif value.startswith('"') and value.endswith('"'):
         return value
     else:
-        return "'{}'".format(value)
+        return f"'{value}'"
 
     
 if __name__ == "__main__":


### PR DESCRIPTION
Avoids bash word-splitting when passing the values to
`npm run build`.

Without this change, we have had to work around the word-
splitting by writing config overrides like:
`{ "site_name": "'Your Platform Here'" }`
(notice that we need both single- and double-quotes)

Example PR working around the status quo: https://github.com/edx/edx-internal/pull/5101