### PR TITLE
fix: make frontend_build handle numeric/bool config values again

### DIFF
--- a/tubular/scripts/frontend_build.py
+++ b/tubular/scripts/frontend_build.py
@@ -7,7 +7,6 @@ Command-line script to build a frontend application.
 import os
 import sys
 from functools import partial
-from typing import Union
 
 import click
 
@@ -73,7 +72,7 @@ def frontend_build(common_config_file, env_config_file, app_name, version_file):
     LOG(f'Frontend app {app_name} built successfully with config file {env_config_file}.')
 
 
-def ensure_wrapped_in_quotes(value: Union[bool, int, float, str, None]) -> str:
+def ensure_wrapped_in_quotes(value) -> str:
     """
     Given a simple value from YAML, return it wrapped in single quotes, unless it
     is already wrapped in quotes, in which case return it as-is.
@@ -91,6 +90,14 @@ def ensure_wrapped_in_quotes(value: Union[bool, int, float, str, None]) -> str:
         "alfredo sauce" -> "alfredo sauce"
         'aglio e olio' -> 'aglio e olio'
     """
+    valid_types = str, int, float, bool, type(None)
+    if not isinstance(value, valid_types):
+        valid_types_string = "|".join(typ.__name__ for typ in valid_types)
+        FAIL(
+            1,
+            f"Expected config value to be of type ({valid_types_string}); "
+            f"instead got value {value!r}, which is of type {type(value).__name__}"
+        )
     string_value = str(value)
     if string_value.startswith("'") and string_value.endswith("'"):
         return string_value

--- a/tubular/scripts/frontend_build.py
+++ b/tubular/scripts/frontend_build.py
@@ -7,6 +7,7 @@ Command-line script to build a frontend application.
 import os
 import sys
 from functools import partial
+from typing import Union
 
 import click
 
@@ -72,9 +73,9 @@ def frontend_build(common_config_file, env_config_file, app_name, version_file):
     LOG(f'Frontend app {app_name} built successfully with config file {env_config_file}.')
 
 
-def ensure_wrapped_in_quotes(value: str) -> str:
+def ensure_wrapped_in_quotes(value: Union[bool, int, float, str, None]) -> str:
     """
-    Given a string, return it wrapped in single quotes, unless it
+    Given a simple value from YAML, return it wrapped in single quotes, unless it
     is already wrapped in quotes, in which case return it as-is.
 
     This ensures that strings passed as arguments to npm bash scripts are treated
@@ -90,12 +91,13 @@ def ensure_wrapped_in_quotes(value: str) -> str:
         "alfredo sauce" -> "alfredo sauce"
         'aglio e olio' -> 'aglio e olio'
     """
-    if value.startswith("'") and value.endswith("'"):
-        return value
-    elif value.startswith('"') and value.endswith('"'):
-        return value
+    string_value = str(value)
+    if string_value.startswith("'") and string_value.endswith("'"):
+        return string_value
+    elif string_value.startswith('"') and string_value.endswith('"'):
+        return string_value
     else:
-        return f"'{value}'"
+        return f"'{string_value}'"
 
     
 if __name__ == "__main__":

--- a/tubular/tests/example-frontend-config/app.yml
+++ b/tubular/tests/example-frontend-config/app.yml
@@ -1,0 +1,35 @@
+S3_BUCKET_NAME: "coolfrontend.openedx.example.org"
+
+APP_CONFIG:
+
+  # Make sure we can override vars from common config.
+  COMMON_OVERRIDE_ME: overriden_value
+
+  # Check strings with spaces and special chars. Should all yield `key='The // value!'`.
+  VAR_WITH_SINGLE_QUOTES: 'The // value!'
+  VAR_WITH_DOUBLE_QUOTES: "The // value!"
+  VAR_WITH_SINGLE_THEN_DOUBLE_QUOTES: "'The // value!'"
+  # Except this one, which should yield `key="The // value!"`.
+  VAR_WITH_DOUBLE_THEN_SINGLE_QUOTES: '"The // value!"'
+
+  # Check ints. Should all yield `key='-100'`.
+  INT: -100
+  INT_WITH_QUOTES: '-100'
+
+  # Check floats. Should all yield `key='3.14'`.
+  FLOAT: 3.14
+  FLOAT_WITH_QUOTES: '3.14'
+
+  # Check True bools. Should all yield `key='True'`.
+  BOOL_TRUE: true
+  BOOL_TRUE_ANOTHER_WAY: yes  # YAML is funny - this is the same as `true`.
+  BOOL_TRUE_WITH_QUOTES: 'True'  # Uppercase because Python loads this file.
+
+  # Check False bools. Should all yield `key='False'`.
+  BOOL_FALSE: false
+  BOOL_FALSE_ANOTHER_WAY: no  # YAML is funny - this is the same as `false`.
+  BOOL_FALSE_WITH_QUOTES: 'False'  # Uppercase because Python loads this file.
+
+  # Check None. Should all yield `key='None'`.
+  NONE: !!null
+  NONE_WITH_QUOTES: 'None'  # `None` instead of `null` because Python loads this file.

--- a/tubular/tests/example-frontend-config/common.yml
+++ b/tubular/tests/example-frontend-config/common.yml
@@ -1,0 +1,7 @@
+APP_CONFIG:
+
+  # Make sure common values trickle down to app's effective config.
+  COMMON_VAR: common_value
+
+  # Make sure common values can be overriden by app config.
+  COMMON_OVERRIDE_ME: initial_value

--- a/tubular/tests/test_frontend_build.py
+++ b/tubular/tests/test_frontend_build.py
@@ -1,0 +1,66 @@
+"""
+Cursory tests for config handling in frontend_build.py.
+
+Please note that this suite is NOT currently a comprehensive test
+of the frontend build scripts and could use more fleshing out.
+"""
+
+from unittest import TestCase, mock
+
+from ..scripts.frontend_build import frontend_build
+from ..scripts.frontend_utils import FrontendBuilder
+
+TEST_DATA_DIR = "tubular/tests/example-frontend-config"
+
+
+class TestFrontendBuildConfigHandling(TestCase):
+    """
+    Cursory tests for frontend config parsing + marshalling.
+    """
+
+    @mock.patch.object(FrontendBuilder, 'create_version_file')
+    @mock.patch.object(FrontendBuilder, 'build_app')
+    @mock.patch.object(FrontendBuilder, 'install_requirements')
+    def test_frontend_build_config_handling(
+            self, mock_install, mock_build, mock_create_version
+    ):
+        exit_code = None
+        try:
+            frontend_build([
+                "--common-config-file",
+                f"{TEST_DATA_DIR}/common.yml",
+                "--env-config-file",
+                f"{TEST_DATA_DIR}/app.yml",
+                "--app-name",
+                "coolfrontend",
+                "--version-file",
+                f"{TEST_DATA_DIR}/dummy-path_will-not-get-written.json",
+            ])
+        except SystemExit as e:
+            # We expect this exception to be raised when the Click command
+            # completes. The exit code will be 0 if the command was successful.
+            exit_code = e.code
+        assert exit_code == 0
+        assert mock_install.call_count == 1
+        assert mock_build.call_count == 1
+        assert mock_build.call_args[0][0] == [
+            "COMMON_VAR='common_value'",
+            "COMMON_OVERRIDE_ME='overriden_value'",
+            "VAR_WITH_SINGLE_QUOTES='The // value!'",
+            "VAR_WITH_DOUBLE_QUOTES='The // value!'",
+            "VAR_WITH_SINGLE_THEN_DOUBLE_QUOTES='The // value!'",
+            "VAR_WITH_DOUBLE_THEN_SINGLE_QUOTES=\"The // value!\"",
+            "INT='-100'",
+            "INT_WITH_QUOTES='-100'",
+            "FLOAT='3.14'",
+            "FLOAT_WITH_QUOTES='3.14'",
+            "BOOL_TRUE='True'",
+            "BOOL_TRUE_ANOTHER_WAY='True'",
+            "BOOL_TRUE_WITH_QUOTES='True'",
+            "BOOL_FALSE='False'",
+            "BOOL_FALSE_ANOTHER_WAY='False'",
+            "BOOL_FALSE_WITH_QUOTES='False'",
+            "NONE='None'",
+            "NONE_WITH_QUOTES='None'",
+        ]
+        assert mock_create_version.call_count == 1


### PR DESCRIPTION
(Also... `test: add some cursory tests for frontend building`)

I [broke frontend pipelines yesterday](https://github.com/edx/tubular/pull/520#pullrequestreview-665338006) while trying to make sure that all frontend config values were wrapped in quotes before being passed through bash to `npm build`. This worked, except for that I assumed that incoming config values were all strings, which broke frontends with numeric or boolean config settings like `cool_feature: true`.