### PR TITLE
Estute/user retirement archiver params

### DIFF
--- a/tubular/tests/test_retirement_archive_and_cleanup.py
+++ b/tubular/tests/test_retirement_archive_and_cleanup.py
@@ -3,12 +3,14 @@ Test the retirement_archive_and_cleanup.py script
 """
 
 
-from mock import patch, DEFAULT
+import datetime
+from mock import call, patch, DEFAULT
 
 from click.testing import CliRunner
 
 from tubular.scripts.retirement_archive_and_cleanup import (
     ERR_ARCHIVING,
+    ERR_BAD_CLI_PARAM,
     ERR_BAD_CONFIG,
     ERR_DELETING,
     ERR_FETCHING,
@@ -19,7 +21,7 @@ from tubular.scripts.retirement_archive_and_cleanup import (
 from tubular.tests.retirement_helpers import fake_config_file, get_fake_user_retirement
 
 
-def _call_script(cool_off_days=37):
+def _call_script(cool_off_days=37, batch_size=None, dry_run=None, start_date=None, end_date=None):
     """
     Call the archive script with the given params and a generic config file.
     Returns the CliRunner.invoke results
@@ -29,13 +31,20 @@ def _call_script(cool_off_days=37):
         with open('test_config.yml', 'w') as f:
             fake_config_file(f)
 
-        result = runner.invoke(
-            archive_and_cleanup,
-            args=[
-                '--config_file', 'test_config.yml',
-                '--cool_off_days', cool_off_days
-            ]
-        )
+        base_args = [
+            '--config_file', 'test_config.yml',
+            '--cool_off_days', cool_off_days,
+        ]
+        if batch_size:
+            base_args += ['--batch_size', batch_size]
+        if dry_run:
+            base_args += ['--dry_run', dry_run]
+        if start_date:
+            base_args += ['--start_date', start_date]
+        if end_date:
+            base_args += ['--end_date', end_date]
+
+        result = runner.invoke(archive_and_cleanup, args=base_args)
     print(result)
     print(result.output)
     return result
@@ -93,6 +102,65 @@ def test_successful(*args, **kwargs):
 
     assert result.exit_code == 0
     assert 'Archive and cleanup complete' in result.output
+
+
+@patch('tubular.edx_api.BaseApiClient.get_access_token', return_value=('THIS_IS_A_JWT', None))
+@patch('tubular.scripts.retirement_archive_and_cleanup.S3Connection')
+@patch('tubular.scripts.retirement_archive_and_cleanup.Key')
+@patch.multiple(
+    'tubular.edx_api.LmsApi',
+    get_learners_by_date_and_status=DEFAULT,
+    bulk_cleanup_retirements=DEFAULT
+)
+def test_successful_with_batching(*args, **kwargs):
+    mock_get_access_token = args[2]
+    mock_s3connection_class = args[1]
+    mock_get_learners = kwargs['get_learners_by_date_and_status']
+    mock_bulk_cleanup_retirements = kwargs['bulk_cleanup_retirements']
+
+    mock_get_learners.return_value = fake_learners_to_retire()
+
+    result = _call_script(batch_size=2)
+
+    # Called once to get the LMS token
+    assert mock_get_access_token.call_count == 1
+    mock_get_learners.assert_called_once()
+    get_learner_calls = [call(['test1', 'test2']), call(['test3'])]
+    mock_bulk_cleanup_retirements.assert_has_calls(get_learner_calls)
+    s3connection_calls = [call(host='s3.fake_region.amazonaws.com'), call(host='s3.fake_region.amazonaws.com')]
+    assert mock_s3connection_class.call_count == 2
+
+    assert result.exit_code == 0
+    assert 'Archive and cleanup complete for batch #1' in result.output
+    assert 'Archive and cleanup complete for batch #2' in result.output
+
+
+@patch('tubular.edx_api.BaseApiClient.get_access_token', return_value=('THIS_IS_A_JWT', None))
+@patch('tubular.scripts.retirement_archive_and_cleanup.S3Connection')
+@patch('tubular.scripts.retirement_archive_and_cleanup.Key')
+@patch.multiple(
+    'tubular.edx_api.LmsApi',
+    get_learners_by_date_and_status=DEFAULT,
+    bulk_cleanup_retirements=DEFAULT
+)
+def test_successful_dry_run(*args, **kwargs):
+    mock_get_access_token = args[2]
+    mock_s3connection_class = args[1]
+    mock_get_learners = kwargs['get_learners_by_date_and_status']
+    mock_bulk_cleanup_retirements = kwargs['bulk_cleanup_retirements']
+
+    mock_get_learners.return_value = fake_learners_to_retire()
+
+    result = _call_script(dry_run=True)
+
+    # Called once to get the LMS token
+    assert mock_get_access_token.call_count == 1
+    mock_get_learners.assert_called_once()
+    mock_bulk_cleanup_retirements.assert_not_called()
+
+    assert result.exit_code == 0
+    assert 'Dry run. Skipping the step to upload data to' in result.output
+    assert 'This is a dry-run. Exiting before any retirements are cleaned up' in result.output
 
 
 def test_no_config():
@@ -153,3 +221,24 @@ def test_bad_s3_upload(*_):
     result = _call_script()
     assert result.exit_code == ERR_ARCHIVING
     assert 'Unexpected error occurred archiving retirements!' in result.output
+
+
+@patch('tubular.edx_api.BaseApiClient.get_access_token', return_value=('THIS_IS_A_JWT', None))
+def test_conflicting_dates(*_):
+    result = _call_script(start_date=datetime.datetime(2021, 10, 10), end_date=datetime.datetime(2018, 10, 10))
+    assert result.exit_code == ERR_BAD_CLI_PARAM
+    assert 'Conflicting start and end dates passed on CLI' in result.output
+
+
+@patch('tubular.edx_api.BaseApiClient.get_access_token', return_value=('THIS_IS_A_JWT', None))
+@patch(
+    'tubular.scripts.retirement_archive_and_cleanup._get_utc_now',
+    return_value=datetime.datetime(2021, 2, 2, 0, 0)
+)
+def test_conflicting_cool_off_date(*_):
+    result = _call_script(
+        cool_off_days=10,
+        start_date=datetime.datetime(2021, 1, 1), end_date=datetime.datetime(2021, 2, 1)
+    )
+    assert result.exit_code == ERR_BAD_CLI_PARAM
+    assert 'End date cannot occur within the cool_off_days period' in result.output


### PR DESCRIPTION
This PR adds a few improvements:
- Clearing up logging to indicate _which_ file is being published to s3. This is useful in the case that the script errors out after publishing to s3 but before finally clearing the users out of the LMS, which would require manual remediation.
- Adds `start_date` and `end_date` CLI params so we can target a specific set of user retirements for testing purposes
- Adds a `dry_run` CLI param so we can test the script out without impacting anything
- Adds a `batch_size` CLI param to limit the size of the request we are sending to the LMS to clean out retired users. In case we need to run this on a large number of users, being able to batch it reduces the amount of clean up we need to do if we were to hit an error.