### PR TITLE
[FAL-2409] Update PyGithub dependency for Lilac

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -15,7 +15,7 @@ google-api-python-client==1.7.3
 jenkinsapi==0.3.3
 kubernetes==12.0.1
 lxml
-PyGithub==1.43.8
+PyGithub==1.44.1
 pymongo==3.5.1
 pytz==2016.10
 pyyaml==5.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,8 +12,8 @@ cachetools==4.2.1         # via google-auth
 certifi==2020.12.5        # via kubernetes, requests
 cffi==1.14.5              # via cryptography
 chardet==4.0.0            # via requests
-click-log==0.3.2          # via -r requirements/base.in
 click==7.1.2              # via -r requirements/base.in, click-log
+click-log==0.3.2          # via -r requirements/base.in
 cloudflare==2.1.0         # via -r requirements/base.in
 cryptography==3.4.7       # via authlib
 decorator==5.0.5          # via validators
@@ -26,8 +26,8 @@ future==0.16.0            # via -r requirements/base.in, cloudflare
 gitdb==4.0.7              # via gitpython
 gitpython==3.1.14         # via -r requirements/base.in
 google-api-python-client==1.7.3  # via -r requirements/base.in
-google-auth-httplib2==0.1.0  # via google-api-python-client
 google-auth==1.28.0       # via google-api-python-client, google-auth-httplib2, kubernetes
+google-auth-httplib2==0.1.0  # via google-api-python-client
 httplib2==0.19.1          # via google-api-python-client, google-auth-httplib2
 idna==2.10                # via requests
 jenkinsapi==0.3.3         # via -r requirements/base.in
@@ -36,23 +36,23 @@ kubernetes==12.0.1        # via -r requirements/base.in
 lxml==4.6.3               # via -r requirements/base.in
 oauthlib==3.1.0           # via atlassian-python-api, requests-oauthlib
 pbr==5.5.1                # via stevedore
-pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
+pyasn1-modules==0.2.8     # via google-auth
 pycparser==2.20           # via cffi
-pygithub==1.43.8          # via -r requirements/base.in
+pygithub==1.44.1          # via -r requirements/base.in
 pyjwt==1.7.1              # via edx-rest-api-client, pygithub
 pymongo==3.5.1            # via -r requirements/base.in, edx-opaque-keys
 pyparsing==2.4.7          # via httplib2
 python-dateutil==2.8.1    # via freezegun, kubernetes
 pytz==2016.10             # via -r requirements/base.in, jenkinsapi
 pyyaml==5.1               # via -r requirements/base.in, cloudflare, kubernetes
-requests-oauthlib==1.3.0  # via atlassian-python-api, kubernetes
 requests==2.25.1          # via -r requirements/base.in, atlassian-python-api, cloudflare, jenkinsapi, kubernetes, pygithub, requests-oauthlib, sailthru-client, simple-salesforce, slumber, yagocd
+requests-oauthlib==1.3.0  # via atlassian-python-api, kubernetes
 rsa==4.7.2                # via google-auth
 sailthru-client==2.3.5    # via -r requirements/base.in
 simple-salesforce==1.11.1  # via -r requirements/base.in
 simplejson==3.17.2        # via sailthru-client
-six==1.15.0               # via -r requirements/base.in, atlassian-python-api, edx-opaque-keys, freezegun, google-api-python-client, google-auth, google-auth-httplib2, kubernetes, python-dateutil, stevedore, validators, websocket-client, yagocd
+six==1.15.0               # via -r requirements/base.in, atlassian-python-api, edx-opaque-keys, freezegun, google-api-python-client, google-auth, google-auth-httplib2, kubernetes, pygithub, python-dateutil, stevedore, validators, websocket-client, yagocd
 slumber==0.7.1            # via edx-rest-api-client
 smmap==4.0.0              # via gitdb
 stevedore==1.32.0         # via edx-opaque-keys


### PR DESCRIPTION
This will fix the errors when trying to install PyGitHub using newer versions of setuptools that don't support use_2to3.

Command that I've used to generate `base.txt`:
```
pip-compile -v --no-emit-trusted-host --no-emit-index-url --rebuild --upgrade-package PyGithub -o requirements/base.txt requirements/base.in
```

Note: pip-compile reordered some dependencies, but didn't upgrade anything except PyGithub.

Same fix for `master`: https://github.com/edx/tubular/pull/532

**Testing instructions**:

1. Check that package can be installed:
    ```bash
    pip install -e .
    ```
2. Run tests:
    ```
    tox -- -n0
    ```