### PR TITLE
[FAL-2409] Update PyGithub dependency

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,7 +16,7 @@ google-api-python-client==1.7.3
 jenkinsapi==0.3.3
 kubernetes==12.0.1
 lxml
-PyGithub==1.43.8
+PyGithub==1.44.1
 pymongo==3.5.1
 pytz==2016.10
 pyyaml==5.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,9 +10,9 @@ authlib==0.15.4
     # via simple-salesforce
 backoff==1.5.0
     # via -r requirements/base.in
-boto3==1.18.28
-    # via -r requirements/base.in
 boto==2.43.0
+    # via -r requirements/base.in
+boto3==1.18.28
     # via -r requirements/base.in
 botocore==1.21.28
     # via
@@ -28,12 +28,12 @@ cffi==1.14.6
     # via cryptography
 charset-normalizer==2.0.4
     # via requests
-click-log==0.3.2
-    # via -r requirements/base.in
 click==8.0.1
     # via
     #   -r requirements/base.in
     #   click-log
+click-log==0.3.2
+    # via -r requirements/base.in
 cloudflare==2.1.0
     # via -r requirements/base.in
 cryptography==3.4.8
@@ -62,21 +62,19 @@ gitpython==3.1.18
     # via -r requirements/base.in
 google-api-python-client==1.7.3
     # via -r requirements/base.in
-google-auth-httplib2==0.1.0
-    # via google-api-python-client
 google-auth==2.0.1
     # via
     #   google-api-python-client
     #   google-auth-httplib2
     #   kubernetes
+google-auth-httplib2==0.1.0
+    # via google-api-python-client
 httplib2==0.19.1
     # via
     #   google-api-python-client
     #   google-auth-httplib2
 idna==3.2
     # via requests
-importlib-metadata==4.6.4
-    # via click
 jenkinsapi==0.3.3
     # via -r requirements/base.in
 jmespath==0.10.0
@@ -95,15 +93,15 @@ oauthlib==3.1.1
     #   requests-oauthlib
 pbr==5.6.0
     # via stevedore
-pyasn1-modules==0.2.8
-    # via google-auth
 pyasn1==0.4.8
     # via
     #   pyasn1-modules
     #   rsa
+pyasn1-modules==0.2.8
+    # via google-auth
 pycparser==2.20
     # via cffi
-pygithub==1.43.8
+pygithub==1.44.1
     # via -r requirements/base.in
 pyjwt==1.7.1
     # via
@@ -129,10 +127,6 @@ pyyaml==5.4
     #   -r requirements/base.in
     #   cloudflare
     #   kubernetes
-requests-oauthlib==1.3.0
-    # via
-    #   atlassian-python-api
-    #   kubernetes
 requests==2.26.0
     # via
     #   -r requirements/base.in
@@ -146,6 +140,10 @@ requests==2.26.0
     #   simple-salesforce
     #   slumber
     #   yagocd
+requests-oauthlib==1.3.0
+    # via
+    #   atlassian-python-api
+    #   kubernetes
 rsa==4.7.2
     # via google-auth
 s3transfer==0.5.0
@@ -165,6 +163,7 @@ six==1.16.0
     #   google-api-python-client
     #   google-auth-httplib2
     #   kubernetes
+    #   pygithub
     #   python-dateutil
     #   stevedore
     #   validators
@@ -175,10 +174,6 @@ smmap==4.0.0
     # via gitdb
 stevedore==1.32.0
     # via edx-opaque-keys
-typing-extensions==3.10.0.0
-    # via
-    #   gitpython
-    #   importlib-metadata
 unicodecsv==0.14.1
     # via -r requirements/base.in
 uritemplate==3.0.1
@@ -198,8 +193,6 @@ wrapt==1.11.2
     #   deprecated
 yagocd==0.4.4
     # via -r requirements/base.in
-zipp==3.5.0
-    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
This PR addresses [concern](https://github.com/edx/tubular/pull/529#issuecomment-915342357) about updating too many dependencies.

Command used to generate `base.txt`:
```
pip-compile -v --no-emit-trusted-host --no-emit-index-url --rebuild --upgrade-package PyGithub -o requirements/base.txt requirements/base.in
```

Testing instructions:

**Testing instructions**:

1. Check that package can be installed:
    ```bash
    pip install -e .
    ```
2. Run tests:
    ```
    tox -- -n0
    ```