### PR TITLE
fix: Don't try to merge security patches when there aren't any

### DIFF
--- a/tubular/git_repo.py
+++ b/tubular/git_repo.py
@@ -154,9 +154,10 @@ class LocalGitAPI:
     def octopus_merge(self, base_branch, commitishes):
         """
         Merge all ``commitishes`` into ``base_branch`` in this repo.
+        ``base_branch`` will be checked out.
         """
         self.checkout_branch(base_branch)
-        if commitishes:
+        if len(commitishes):
             self.repo.git.merge(*commitishes)
         return self.get_head_sha()
 

--- a/tubular/git_repo.py
+++ b/tubular/git_repo.py
@@ -157,6 +157,9 @@ class LocalGitAPI:
         ``base_branch`` will be checked out.
         """
         self.checkout_branch(base_branch)
+        # Specifically use len here so that generators cause an
+        # exception (`if commitishes` with a generator would always
+        # return True)
         if len(commitishes):
             self.repo.git.merge(*commitishes)
         return self.get_head_sha()

--- a/tubular/scripts/merge_approved_prs.py
+++ b/tubular/scripts/merge_approved_prs.py
@@ -153,7 +153,7 @@ def octomerge(
             release_name,
             ref=deploy_sha,
         )
-        # Logging the push info may help us detect a race condition where concurrent builds
+        # `log_info=True` may help us detect a race condition where concurrent builds
         # both push the target branch, although the tags really matter much more.
         local_repo.push_branch(target_branch, force=True, log_info=True)
         local_repo.push_tags()

--- a/tubular/scripts/merge_approved_prs.py
+++ b/tubular/scripts/merge_approved_prs.py
@@ -141,7 +141,7 @@ def octomerge(
                     for pr in approved_prs
                 )
             ))
-            local_repo.octopus_merge(target_branch, (pr.head.sha for pr in approved_prs))
+            local_repo.octopus_merge(target_branch, [pr.head.sha for pr in approved_prs])
         else:
             logging.info("No PRs to merge")
 

--- a/tubular/scripts/merge_approved_prs.py
+++ b/tubular/scripts/merge_approved_prs.py
@@ -132,30 +132,35 @@ def octomerge(
         approved_prs = list(find_approved_prs(
             target_github_repo, source_github_repo, target_base_branch, source_base_branch
         ))
-        logging.info("Merging the following prs into {}:\n{}".format(
-            target_branch,
-            "\n".join(
-                "    {.html_url}".format(pr)
-                for pr in approved_prs
-            )
-        ))
 
-        merge_sha = local_repo.octopus_merge(target_branch, (pr.head.sha for pr in approved_prs))
+        if approved_prs:
+            logging.info("Merging the following prs into {}:\n{}".format(
+                target_branch,
+                "\n".join(
+                    "    {.html_url}".format(pr)
+                    for pr in approved_prs
+                )
+            ))
+            local_repo.octopus_merge(target_branch, (pr.head.sha for pr in approved_prs))
+        else:
+            logging.info("No PRs to merge")
+
         # The tag encodes the time to ensure that it is a distinct tag.
         release_name = 'release-{date}'.format(date=datetime.now().strftime("%Y%m%d%H%M%S"))
-        logging.info(f"Octopus merge commit is {merge_sha} and will be tagged as {release_name}")
-        logging.info(f"Target branch now locally at commit {local_repo.get_head_sha(branch=target_branch)}")
+        deploy_sha = local_repo.get_head_sha(branch=target_branch)
+        logging.info(f"Pushing commit {deploy_sha} to {target_branch} branch and tagging as {release_name}")
         local_repo.repo.create_tag(
             release_name,
-            ref=merge_sha,
+            ref=deploy_sha,
         )
+        # Logging the push info may help us detect a race condition where concurrent builds
+        # both push the target branch, although the tags really matter much more.
         local_repo.push_branch(target_branch, force=True, log_info=True)
-        logging.info(f"Target branch, after push, is at commit {local_repo.get_head_sha(branch=target_branch)}")
         local_repo.push_tags()
 
         results = {
             'target_branch': target_branch,
-            sha_variable: merge_sha,
+            sha_variable: deploy_sha,
             'merged_prs': [
                 {'html_url': pr.html_url}
                 for pr in approved_prs


### PR DESCRIPTION
When there are no approved PRs, don't perform a merge -- just take the
source_branch commitish as the deployment SHA and new target_branch value.

When `octopus_merge` was called with an empty `approved_prs` list, it was
invoking the no-arg version of `git merge`, which merges the upstream
branch instead (as an implicit argument). So, instead of creating a single
commit off of each source-branch commit, the target-branch commits formed
a *chain* parallel to the source branch (each having two parents -- one a
source branch commit, and the other the previous target-branch commit.)

From `git help merge`

> If no commit is given from the command line, merge the remote-tracking
> branches that the current branch is configured to use as its upstream.

This was probably harmless but created a git history that was overly
difficult to understand.

Also:

- Rename `merge_sha` variable to `deploy_sha` to clarify intent, especially
  since it is now not always a merge commit
- Remove some logging that turned out to be redundant (logging had been
  added to figure out where that strange merge commit was coming from)

ref: ARCHBOM-1895