### PR TITLE
feat: Remove `--source-branch` from merge-approved-prs

### DIFF
--- a/tubular/git_repo.py
+++ b/tubular/git_repo.py
@@ -173,12 +173,13 @@ class LocalGitAPI:
 
     def force_branch_to(self, branch, commitish, remote=None):
         """
-        Reset branch to commitish.
+        Reset branch to commitish, which must be a commit ID if remote is None,
+        or a remote branch name if a remote is named.
 
         Arguments:
             branch: the branch to reset
             commitish: The commit to reset the branch to.
-            remote: The remote containing ``commitish``.
+            remote: The remote containing branch named by ``commitish``.
         """
         if remote:
             commitish = self.repo.remotes[remote].refs[commitish]


### PR DESCRIPTION
This completes the work done in PR #548/commit 5c65880, possible now that
edx-internal has been updated to use `--source-deploy-commit` instead.

Also update `force_branch_to` docs. The `remote` option is no longer being
used, but leave it in since we know it works.

ref: ARCHBOM-1895