### PR TITLE
fix: reduced batch size due to userRateLimitExceeded

### DIFF
--- a/tubular/google_api.py
+++ b/tubular/google_api.py
@@ -31,7 +31,7 @@ LOG = logging.getLogger(__name__)
 
 # The maximum number of requests per batch is 100, according to the google API docs.
 # However, cap our number lower than that maximum to avoid throttling errors and backoff.
-GOOGLE_API_MAX_BATCH_SIZE = 20
+GOOGLE_API_MAX_BATCH_SIZE = 10
 
 # Mimetype used for Google Drive folders.
 FOLDER_MIMETYPE = 'application/vnd.google-apps.folder'


### PR DESCRIPTION
Fix for the following build failure : http://jenkins-new.analytics.edx.org/job/retirement-partner-report-cleanup/99/
In the API Console, there is a similar quota referred to as Requests per 100 seconds per user. By default, it is set to 100 requests per 100 seconds per user and can be adjusted to a maximum value of 1,000. But the number of requests to the API is restricted to a maximum of 10 requests per second per user. You can refer following document :https://developers.google.com/analytics/devguides/config/mgmt/v3/limits-quotas