### PR TITLE
Update DriveApi to add support for user accounts

### DIFF
--- a/tubular/scripts/delete_expired_partner_gdpr_reports.py
+++ b/tubular/scripts/delete_expired_partner_gdpr_reports.py
@@ -80,7 +80,19 @@ def _config_or_exit(config_file, google_secrets_file):
     type=int,
     help='Days ago from the current time - before which all GDPR partner reports will be deleted.'
 )
-def delete_expired_reports(config_file, google_secrets_file, age_in_days):
+@click.option(
+    '--as_user_account',
+    is_flag=True,
+    help=(
+        'Whether or not the given secrets file is an OAuth2 JSON token, '
+        'which means that the authentication is done using a '
+        'user account, and NOT a service account.'
+    ),
+    show_default=True,
+)
+def delete_expired_reports(
+    config_file, google_secrets_file, age_in_days, as_user_account
+):
     """
     Performs the partner report deletion as needed.
     """
@@ -101,7 +113,9 @@ def delete_expired_reports(config_file, google_secrets_file, age_in_days):
 
     try:
         delete_before_dt = datetime.now(UTC) - timedelta(days=age_in_days)
-        drive = DriveApi(config['google_secrets_file'])
+        drive = DriveApi(
+            config['google_secrets_file'], as_user_account=as_user_account
+        )
         LOG('DriveApi configured')
         drive.delete_files_older_than(
             config['drive_partners_folder'],

--- a/tubular/tests/test_delete_expired_reports.py
+++ b/tubular/tests/test_delete_expired_reports.py
@@ -70,9 +70,21 @@ def test_successful_report_deletion(*args):
     file_prefix = '{}_{}'.format(REPORTING_FILENAME_PREFIX, TEST_PLATFORM_NAME)
 
     mock_walk_files.return_value = [
-        {'id': 'folder1', 'name': '{}.csv'.format(file_prefix), 'createdTime': test_created_date},
-        {'id': 'folder2', 'name': '{}_foo.csv'.format(file_prefix), 'createdTime': test_created_date},
-        {'id': 'folder3', 'name': '{}___bar.csv'.format(file_prefix), 'createdTime': test_created_date},
+        {
+            'id': 'folder1',
+            'name': '{}.csv'.format(file_prefix),
+            'createdTime': test_created_date,
+        },
+        {
+            'id': 'folder2',
+            'name': '{}_foo.csv'.format(file_prefix),
+            'createdTime': test_created_date,
+        },
+        {
+            'id': 'folder3',
+            'name': '{}___bar.csv'.format(file_prefix),
+            'createdTime': test_created_date,
+        },
     ]
     mock_delete_files.return_value = None
     mock_driveapi.return_value = None
@@ -98,9 +110,21 @@ def test_deletion_report_no_matching_files(*args):
 
     test_created_date = '2018-07-13T22:21:45.600275+00:00'
     mock_walk_files.return_value = [
-        {'id': 'folder1', 'name': 'not_this.csv', 'createdTime': test_created_date},
-        {'id': 'folder2', 'name': 'or_this.csv', 'createdTime': test_created_date},
-        {'id': 'folder3', 'name': 'foo.csv', 'createdTime': test_created_date},
+        {
+            'id': 'folder1',
+            'name': 'not_this.csv',
+            'createdTime': test_created_date,
+        },
+        {
+            'id': 'folder2',
+            'name': 'or_this.csv',
+            'createdTime': test_created_date,
+        },
+        {
+            'id': 'folder3',
+            'name': 'foo.csv',
+            'createdTime': test_created_date,
+        },
     ]
     mock_delete_files.return_value = None
     mock_driveapi.return_value = None


### PR DESCRIPTION
Update the `google_api.py` module to add user account authentication support for the `DriveApi` class. This also adds an `--as_user_account` option to the `delete_expired_partner_gdpr_reports.py` script.