### PR TITLE
build: Stop testing on Python 3.6 and 3.7

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.8']
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38}
+envlist = py{38}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
3.8 is the only version we support right now.