### PR TITLE
fix: Send correct data to retirement partner report.

### DIFF
--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -339,9 +339,8 @@ class LmsApi(BaseApiClient):
         """
         Removes the given users from the partner reporting queue
         """
-        data = {'usernames': usernames}
         api_url = self.get_api_url('api/user/v1/accounts/retirement_partner_report_cleanup')
-        return self._request('POST', api_url, json=data)
+        return self._request('POST', api_url, json=usernames)
 
     @_retry_lms_api()
     def retirement_retire_proctoring_data(self, learner):

--- a/tubular/tests/test_edx_api.py
+++ b/tubular/tests/test_edx_api.py
@@ -210,9 +210,7 @@ class TestLmsApi(OAuth2Mixin, unittest.TestCase):
 
     @patch.object(edx_api.LmsApi, 'retirement_partner_cleanup')
     def test_retirement_partner_cleanup(self, mock_method):
-        json_data = {
-            'usernames': FAKE_USERNAMES,
-        }
+        json_data = FAKE_USERNAMES
         responses.add(
             POST,
             urljoin(self.lms_base_url, 'api/user/v1/accounts/retirement_partner_report_cleanup/'),


### PR DESCRIPTION
This endpoint accepts data as a list and not as
a dictionary. Updating the call to correct this issue.