### PR TITLE
fix: Duplicate checking blocking unique messages 

### DIFF
--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -29,7 +29,6 @@ LOG.setLevel(logging.INFO)
 
 PR_PREFIX = '**EdX Release Notice**: '
 PR_MESSAGE_FORMAT = '{prefix} {message} {extra_text}'
-PR_MESSAGE_FILTER = '{prefix} {message}'
 
 PR_ON_STAGE = 'in preparation for a release to production.'
 PR_ON_STAGE_DATE_EXTRA = 'in preparation for a release to production on {date:%A, %B %d, %Y}. {extra_text}'
@@ -1044,13 +1043,15 @@ class GitHubAPI:
             else:
                 extra_text = PR_ON_STAGE_DATE_EXTRA.format(date=deploy_date, extra_text=extra_text)
 
-        return self.message_pull_request(
-            pr_number,
-            PR_MESSAGE_FORMAT.format(
+        message = PR_MESSAGE_FORMAT.format(
                 prefix=PR_PREFIX,
                 message=message_type.value,
-                extra_text=extra_text),
-            PR_MESSAGE_FILTER.format(prefix=PR_PREFIX, message=message_type.value),
+                extra_text=extra_text)
+
+        return self.message_pull_request(
+            pr_number,
+            message,
+            message,
             force_message,
         )
 

--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -1020,6 +1020,7 @@ class GitHubAPI:
         if force_message or _not_duplicate(pull_request.get_issue_comments(), message_filter):
             return pull_request.create_issue_comment(message)
         else:
+            LOG.info(f"Not posting duplicate PR message {message} on PR# {pull_request}")
             return None
 
     def message_pr_with_type(self, pr_number, message_type, deploy_date=None, force_message=False, extra_text=''):

--- a/tubular/scripts/message_prs_in_range.py
+++ b/tubular/scripts/message_prs_in_range.py
@@ -73,6 +73,11 @@ LOG = logging.getLogger(__name__)
     u'--extra_text', u'extra_text', default=''
 )
 @click.option(
+    u'--force',
+    help=u'Disable duplicate checking',
+    is_flag=True
+)
+@click.option(
     u'--no-op',
     help=u'Disable posting messages for testing',
     is_flag=True
@@ -88,6 +93,7 @@ def message_pull_requests(org,
                           head_ami_tag_app,
                           message_type,
                           extra_text,
+                          force,
                           no_op):
     u"""
     Message a range of Pull requests between the BASE and HEAD SHA specified.
@@ -128,7 +134,7 @@ def message_pull_requests(org,
     LOG.info("Github API Rate Limit: {}".format(api.get_rate_limit()))
     pull_requests = retrieve_pull_requests(api, base_sha, head_sha)
     for pull_request in pull_requests:
-        message_pr(api, MessageType[message_type], pull_request, extra_text, no_op)
+        message_pr(api, MessageType[message_type], pull_request, extra_text, force, no_op)
 
 
 def get_client(org, repo, token):
@@ -169,7 +175,7 @@ def retrieve_pull_requests(api, base_sha, head_sha):
     return pull_requests
 
 
-def message_pr(api, message_type, pull_request, extra_text, no_op):
+def message_pr(api, message_type, pull_request, extra_text, force_message, no_op):
     u"""
     Send a Message for a Pull request.
 
@@ -191,10 +197,10 @@ def message_pr(api, message_type, pull_request, extra_text, no_op):
         LOG.info(u"Posting message type %r to %d.", message_type.name, pull_request.number)
 
         try:
-            api.message_pr_with_type(pr_number=pull_request, message_type=message_type, extra_text=extra_text)
+            api.message_pr_with_type(pr_number=pull_request, message_type=message_type, force_message=force_message, extra_text=extra_text)
         except UnknownObjectException as exc:
-            LOG.error(u"message_pr_with_type args were: pr_number={0} message_type={1} extra_text={2}".format(
-                pull_request, message_type, extra_text))
+            LOG.error(u"message_pr_with_type args were: pr_number={0} message_type={1} force_message={2}, extra_text={3}".format(
+                pull_request, message_type, force_message, extra_text))
             raise exc
 
 

--- a/tubular/tests/test_github.py
+++ b/tubular/tests/test_github.py
@@ -514,9 +514,13 @@ class GitHubApiTestCase(TestCase):
                         extra_text=''
                     )
                 ),
-                github_api.PR_MESSAGE_FILTER.format(
+                github_api.PR_MESSAGE_FORMAT.format(
                     prefix=github_api.PR_PREFIX,
-                    message=github_api.MessageType.stage.value
+                    message=github_api.MessageType.stage.value,
+                    extra_text=github_api.PR_ON_STAGE_DATE_EXTRA.format(
+                        date=deploy_date,
+                        extra_text=''
+                    )
                 ),
                 False
             )
@@ -539,9 +543,10 @@ class GitHubApiTestCase(TestCase):
                         message=github_api.MessageType.stage.value,
                         extra_text=github_api.PR_ON_STAGE_DATE_EXTRA.format(date=deploy_date, extra_text='')
                     ),
-                    github_api.PR_MESSAGE_FILTER.format(
+                    github_api.PR_MESSAGE_FORMAT.format(
                         prefix=github_api.PR_PREFIX,
-                        message=github_api.MessageType.stage.value
+                        message=github_api.MessageType.stage.value,
+                        extra_text=github_api.PR_ON_STAGE_DATE_EXTRA.format(date=deploy_date, extra_text='')
                     ),
                     False
                 )
@@ -563,9 +568,10 @@ class GitHubApiTestCase(TestCase):
                     message=message_type.value,
                     extra_text=extra_text
                 ),
-                github_api.PR_MESSAGE_FILTER.format(
+                github_api.PR_MESSAGE_FORMAT.format(
                     prefix=github_api.PR_PREFIX,
-                    message=message_type.value
+                    message=message_type.value,
+                    extra_text=extra_text
                 ),
                 force_message
             )


### PR DESCRIPTION
The message prs function in the library already had a force flag to
disable duplicate checking, this just adds wiring so that you can use
it from a command line flag.

I can't figure out the exact history. I don't understand why the
duplicate check didn't include extra_text. It may be due to having
release dates in the messages years ago. This fixes the issue I'm
haivng with similar message types, with different extra_text for
different app-permissons jobs preventing messages being posted for all
but the first job to finish.