### PR TITLE
fix: The error logging for FrontendBuilder object needs two arguments supplied

### DIFF
--- a/tubular/scripts/frontend_utils.py
+++ b/tubular/scripts/frontend_utils.py
@@ -59,7 +59,7 @@ class FrontendBuilder:
         proc = subprocess.Popen(['npm install'], cwd=self.app_name, shell=True)
         return_code = proc.wait()
         if return_code != 0:
-            self.FAIL('Could not run `npm install` for app {}.'.format(self.app_name))
+            self.FAIL(1, 'Could not run `npm install` for app {}.'.format(self.app_name))
 
         self.install_requirements_npm_aliases()
 
@@ -71,7 +71,7 @@ class FrontendBuilder:
             proc = subprocess.Popen(['npm install npm@8'], cwd=self.app_name, shell=True)
             return_code = proc.wait()
             if return_code != 0:
-                self.FAIL('Could not run `npm install npm@8` for app {}.'.format(self.app_name))
+                self.FAIL(1, 'Could not run `npm install npm@8` for app {}.'.format(self.app_name))
 
             aliased_installs = ' '.join(['{}@{}'.format(k, v) for k, v in npm_aliases.items()])
             # Use the locally installed npm at ./node_modules/.bin/npm
@@ -82,7 +82,7 @@ class FrontendBuilder:
             )
             install_aliases_proc_return_code = install_aliases_proc.wait()
             if install_aliases_proc_return_code != 0:
-                self.FAIL('Could not run `npm install` aliases {} for app {}.'.format(
+                self.FAIL(1, 'Could not run `npm install` aliases {} for app {}.'.format(
                     aliased_installs, self.app_name
                 ))
 


### PR DESCRIPTION
This is a bug fix. See the impact of this bug at this [GOCD error message](https://gocd.tools.edx.org/go/tab/build/detail/stage-frontend-app-learning/592/stage_frontend-app-learning_build_frontend/1/stage_frontend-app-learning_build_frontend_job).
Make sure the logging statements supplies 2 arguments