### PR TITLE
fix: tox failures due to multiple package-looking directories

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -16,5 +16,5 @@ jobs:
         architecture: x64
     - run: rm -f /etc/boto.cfg
     - run: pip3 install --upgrade pip setuptools
-    - run: pip3 install 'tox<4.0'
+    - run: pip3 install 'tox'
     - run: tox -- -n0

--- a/admin/boto_to_add_ingress.py
+++ b/admin/boto_to_add_ingress.py
@@ -1,1 +1,0 @@
-../tubular/admin/boto_to_add_ingress.py


### PR DESCRIPTION
but best I can tell we no longer use this script so let's just get rid of it

If tox hangs on this then my experiment was a failure