### PR TITLE
fix: adding new method to fetch all check runs by commit.

### DIFF
--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -433,9 +433,13 @@ class GitHubAPI:
             raise UnknownObjectException(
                 500, "commit is neither a valid sha nor github.Commit.Commit object."
             )
+
+        # in platform we have 39 checks.
+        parameters = {'per_page': 100}
         _, data = commit._requester.requestJsonAndCheck(  # pylint: disable=protected-access
             "GET",
             commit.url + "/check-runs",
+            parameters = parameters,
             headers={"Accept": "application/vnd.github.antiope-preview+json"}
         )
 
@@ -529,7 +533,7 @@ class GitHubAPI:
         """
         if any(state in ('pending', None) for (state, url) in results.values()):
             return 'pending'
-        if all(state in ('success', 'neutral') for (state, url) in results.values()):
+        if all(state in ('success', 'neutral', 'skipped') for (state, url) in results.values()):
             return 'success'
         return 'failure'
 

--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -422,7 +422,7 @@ class GitHubAPI:
                 - Commit (directly gets the combined status)
 
         Returns:
-            Json representing the check suites
+            Json representing the check runs
         """
         self.log_rate_limit()
         if isinstance(commit, six.string_types):
@@ -501,7 +501,8 @@ class GitHubAPI:
         try:
             branch = self.github_repo.get_branch(self.github_repo.default_branch)
             if branch:
-                required_status_checks = branch._rawData['protection']['required_status_checks']['contexts']
+
+                required_status_checks = branch.raw_data['protection']['required_status_checks']['contexts']
         except Exception as err:  # pylint: disable=broad-except
             LOG.warning("Error occurred white getting branch protection rules: {0}".format(err))
 

--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -450,7 +450,7 @@ class GitHubAPI:
             dict mapping context names to (result, url) tuples
         """
         self.log_rate_limit()
-        required_checks = self.get_branch_protection_rules('master')
+        required_checks = self.get_branch_protection_rules()
 
         results = {}
         combined_status = self.get_commit_combined_statuses(commit)
@@ -487,17 +487,15 @@ class GitHubAPI:
 
     @backoff.on_exception(backoff.expo, (RateLimitExceededException, socket.timeout), max_tries=7,
                           jitter=backoff.random_jitter, on_backoff=_backoff_logger)
-    def get_branch_protection_rules(self, branch):
+    def get_branch_protection_rules(self):
         """
         reference can be found here https://docs.github.com/en/rest/reference/repos#branches
-        Arguments:
-            branch: branch name.
         Returns:
-            lists on required checks.
+            lists of required checks.
         """
         required_status_checks = []
         try:
-            branch = self.github_repo.get_branch(branch)
+            branch = self.github_repo.get_branch(self.github_repo.default_branch)
             if branch:
                 required_status_checks = branch._rawData['protection']['required_status_checks']['contexts']
         except Exception as err:  # pylint: disable=broad-except

--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -461,6 +461,12 @@ class GitHubAPI:
             for status in combined_status.statuses
         })
 
+        ignore_check_runs = [
+            'collect-and-verify',
+            'edx-platform-ci-openedx',
+            'gh-hosted-python-${{ matrix.python-version }},django-${{ matrix.django-version }},${{ matrix.shard_name }}'
+        ]
+
         check_suites = self.get_commit_check_suites(commit)
         results.update({
             suite['app']['name']: (
@@ -468,14 +474,11 @@ class GitHubAPI:
                 suite['url']
             )
             for suite in check_suites['check_suites']
+            if suite['app']['name'] not in ignore_check_runs
         })
 
         # get more results from commit check runs
-        ignore_check_runs = [
-            'gh-hosted-python-${{ matrix.python-version }},django-${{ matrix.django-version }},${{ matrix.shard_name }}'
-        ]
         check_runs = self.get_commit_check_runs(commit)
-
         results.update({
             suite['name']: (
                 suite.get('conclusion').lower() if suite.get('conclusion') is not None else 'pending',

--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -471,6 +471,9 @@ class GitHubAPI:
         })
 
         # get more results from commit check runs
+        ignore_check_runs = [
+            'gh-hosted-python-${{ matrix.python-version }},django-${{ matrix.django-version }},${{ matrix.shard_name }}'
+        ]
         check_runs = self.get_commit_check_runs(commit)
 
         results.update({
@@ -479,6 +482,7 @@ class GitHubAPI:
                 suite['url']
             )
             for suite in check_runs['check_runs']
+            if suite['name'] not in ignore_check_runs
         })
 
         return results

--- a/tubular/scripts/check_pr_tests_status.py
+++ b/tubular/scripts/check_pr_tests_status.py
@@ -119,7 +119,7 @@ def check_tests(
 
     for test_name, details in test_statuses.items():
         _url, test_status_string = details.split(" ", 1)
-        test_status_success = bool(test_status_string == "success")
+        test_status_success = bool(test_status_string in ["success", "skipped"])
         if not test_status_success:
             if test_name in ignore_list:
                 LOG.info("Ignoring failure of \"{test_name}\" because it is in the ignore list".format(

--- a/tubular/tests/test_github.py
+++ b/tubular/tests/test_github.py
@@ -276,7 +276,6 @@ class GitHubApiTestCase(TestCase):
             commit_mock.get_combined_status.return_value = mock_combined_status
             self.repo_mock.get_commit.return_value = commit_mock
 
-            # self.repo_mock.get_branch._rawData.return_value = {'protection': {'required_status_checks': ['abc']}}
             commit_mock._requester = Mock()  # pylint: disable=protected-access
             # pylint: disable=protected-access
             commit_mock._requester.requestJsonAndCheck.return_value = (


### PR DESCRIPTION
Existing checks are showing misleading statuses. I am adding a new check to fetch all check runs by a commit.
https://pygithub.readthedocs.io/en/latest/github_objects/Commit.html#github.Commit.Commit.get_check_runs

1. Added new method to check branch protection rules also.
2. Considering skipped as success also. Otherwise skipped check failed the whole result.

**steps to run command**

1. `check_pr_tests_status.py --org openedx --repo edx-platform --pr_number 31492`

2. `check_pr_tests_status.py --org openedx --repo edx-platform --commit_hash 2157e7714ab6716b2cfac72459cb71fc782ea6f7`

