### PR TITLE
Pick urls ready to merge

### DIFF
--- a/scripts/get_ready_to_merge_prs.py
+++ b/scripts/get_ready_to_merge_prs.py
@@ -1,0 +1,1 @@
+../tubular/scripts/alert_opsgenie.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ console_scripts =
     validate_edp.py = tubular.scripts.validate_edp:validate_cli
     submit_slack_msg.py = tubular.scripts.submit_slack_msg:submit_slack_msg
     alert_opsgenie.py = tubular.scripts.alert_opsgenie:alert_opsgenie
+    get_ready_to_merge_prs.py = tubular.scripts.get_ready_to_merge_prs:get_ready_to_merge_prs
 
 [extras]
 dev =

--- a/tubular/scripts/get_ready_to_merge_prs.py
+++ b/tubular/scripts/get_ready_to_merge_prs.py
@@ -1,0 +1,92 @@
+#! /usr/bin/env python3
+
+"""
+Command-line script to get open prs with label 'Ready to merge'
+"""
+import json
+import logging
+import sys
+from os import path
+
+import click
+import requests
+
+# Add top-level module path to sys.path before importing tubular code.
+sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+LOG = logging.getLogger(__name__)
+
+GIT_API_URL = 'https://api.github.com/search/issues?'
+
+
+@click.command("get_ready_to_merge_prs")
+@click.option(
+    '--org',
+    help='Org from the GitHub repository URL of https://github.com/<org>/<repo>',
+    default='edx'
+)
+@click.option(
+    '--token',
+    envvar='GIT_TOKEN',
+    help='The github access token, see https://help.github.com/articles/creating-an-access-token-for-command-line-use/'
+)
+def get_ready_to_merge_prs(org, token):
+    """
+    get a list of all prs which are open and have a label "Ready to merge" in organization.
+
+    Args:
+        org (str):
+        token (str):
+
+    Returns:
+            list of all prs.
+    """
+    urls = get_github_api_response(org, token)
+    print(urls)
+    return urls
+
+
+def get_github_api_response(org, token):
+    """
+    get github pull requests
+    https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests
+    """
+    LOG.info("Preparing to hit api")
+    params = 'q=is:pr is:open label:"Ready to merge" org:{org}'.format(org=org)
+    headers = {
+        'Accept': "application/vnd.github.antiope-preview+json",
+        'Authorization': "bearer {token}".format(token=token),
+    }
+    data = []
+
+    try:
+        resp = requests.get(GIT_API_URL, params=params, headers=headers)
+        if resp.status_code == 200:
+            data = resp.json()
+            LOG.info("Got {count} prs.".format(count=data['total_count']))
+            data = [item['html_url'] for item in data['items']]
+            data = json.dumps(data)
+            return data
+
+        else:
+            LOG.error(
+                'api return status code {code} and error {con}'.format(code=resp.status_code, con=resp.content)
+            )
+
+    except Exception as err:  # pylint: disable=broad-except
+        LOG.error('Github api throws error: {con}'.format(con=str(err)))
+
+    return data
+
+
+def parse_urls(data):
+    """
+    parse data to return only org, repo and pull request number
+    """
+    raw_data = data.replace('https://github.com/', '').split('/')
+    return raw_data[0], raw_data[1], raw_data[3]
+
+
+if __name__ == "__main__":
+    get_ready_to_merge_prs()  # pylint: disable=no-value-for-parameter

--- a/tubular/tests/test_ready_to_merge_prs.py
+++ b/tubular/tests/test_ready_to_merge_prs.py
@@ -1,0 +1,71 @@
+"""
+Tests of the code to get open prs with label 'Ready to merge'
+"""
+import json
+import unittest
+from unittest import mock
+
+from tubular.scripts.get_ready_to_merge_prs import get_github_api_response
+
+
+class TestReadyToMergePRS(unittest.TestCase):
+    """
+    Tests cases for open prs with label 'Ready to merge'
+    """
+    def setUp(self):
+        super().setUp()
+        self.content = {
+            "total_count": 1,
+            "incomplete_results": "false",
+            "items": [
+                {
+                    "url": "https://api.github.com/repos/openedx/edx-toggles/issues/246",
+                    "repository_url": "https://api.github.com/repos/openedx/edx-toggles",
+                    "labels_url": "https://api.github.com/repos/openedx/edx-toggles/issues/246/labels{/name}",
+                    "comments_url": "https://api.github.com/repos/openedx/edx-toggles/issues/246/comments",
+                    "html_url": "https://github.com/openedx/edx-platform/pull/300001",
+                },
+                {
+                    "url": "https://api.github.com/repos/openedx/edx-toggles/issues/246",
+                    "repository_url": "https://api.github.com/repos/openedx/edx-toggles",
+                    "labels_url": "https://api.github.com/repos/openedx/edx-toggles/issues/246/labels{/name}",
+                    "comments_url": "https://api.github.com/repos/openedx/edx-toggles/issues/246/comments",
+                    "html_url": "https://github.com/openedx/edx-toggles/pull/2001",
+                }]
+        }
+
+    def _mock_response(self, status=200, json_data=None, raise_for_status=None):
+        """
+        mock the response.
+        """
+        mock_resp = mock.Mock()
+        mock_resp.raise_for_status = mock.Mock()
+        if raise_for_status:
+            mock_resp.raise_for_status.side_effect = raise_for_status
+
+        mock_resp.status_code = status
+
+        mock_resp.json = mock.Mock(return_value=json_data)
+        return mock_resp
+
+    @mock.patch('requests.get')
+    def test_apis(self, mock_get):
+        """ verify method returns the valid pr links """
+        mock_resp = self._mock_response(json_data=self.content)
+        mock_get.return_value = mock_resp
+        content = get_github_api_response('openedx', '12345')
+        expected = [item['html_url'] for item in self.content['items']]
+        self.assertEqual(json.dumps(expected), content)
+
+    @mock.patch('requests.get')
+    def test_apis_without_records(self, mock_get):
+        """ verify code works in case of no results """
+        mock_resp = self._mock_response(json_data={'total_count': 0, 'incomplete_results': False, 'items': []})
+        mock_get.return_value = mock_resp
+        content = get_github_api_response('openedx', '12345')
+        self.assertEqual(json.dumps([]), content)
+
+    def test_apis_with_errors(self):
+        """ test in case of exception"""
+        with mock.patch('tubular.scripts.get_ready_to_merge_prs.requests.get', side_effect=Exception("error")):
+            get_github_api_response('openedx', '12345')


### PR DESCRIPTION
Get all open prs with label `Ready to merge`

How to runn
```
get_ready_to_merge_prs.py --org openedx --token *******

INFO:tubular.scripts.get_ready_to_merge_prs:Preparing to hit api
INFO:tubular.scripts.get_ready_to_merge_prs:Got 2 prs.
["https://github.com/openedx/edx-platform/pull/31511", "https://github.com/openedx/edx-toggles/pull/246"]

```