### PR TITLE
feat: add flag to check all PR checks status

### DIFF
--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -177,7 +177,7 @@ class GitHubAPI:
     def __init__(
             self, org, repo, token,
             max_tries=None, initial_wait=None, interval=None,
-            exclude_contexts=None, include_contexts=None
+            exclude_contexts=None, include_contexts=None, all_checks=False
     ):
         """
         Creates a new API access object.
@@ -199,6 +199,7 @@ class GitHubAPI:
         self.org = org
         self.repo = repo
         self._set_up_repo_and_org()
+        self.all_checks = all_checks
 
         if max_tries is None:
             max_tries = envvar_get_int("MAX_PR_TEST_POLL_TRIES", MAX_PR_TEST_TRIES_DEFAULT)
@@ -473,7 +474,7 @@ class GitHubAPI:
                 suite['url']
             )
             for suite in check_suites['check_suites']
-            if suite['app']['name'] in required_checks
+            if self.all_checks or suite['app']['name'] in required_checks
         })
 
         # get more results from commit check runs
@@ -484,7 +485,7 @@ class GitHubAPI:
                 suite['url']
             )
             for suite in check_runs['check_runs']
-            if suite['name'] in required_checks
+            if self.all_checks or suite['name'] in required_checks
         })
 
         return results

--- a/tubular/scripts/check_pr_tests_status.py
+++ b/tubular/scripts/check_pr_tests_status.py
@@ -59,6 +59,12 @@ LOG = logging.getLogger(__name__)
     default=sys.stdout
 )
 @click.option(
+    '--all-checks',
+    help="Check all validation contexts, whehther it is required or not",
+    is_flag=True,
+    default=False
+)
+@click.option(
     '--exclude-contexts',
     help=u"Regex defining which validation contexts to exclude from this status check.",
     default="datreeio|Renovate|[Cc]odecov|Dependabot"
@@ -70,7 +76,7 @@ LOG = logging.getLogger(__name__)
 )
 def check_tests(
         org, repo, token, input_file, pr_number, commit_hash,
-        out_file, exclude_contexts, include_contexts,
+        out_file, all_checks, exclude_contexts, include_contexts,
 ):
     """
     Check the current combined status of a GitHub PR/commit in a repo once.
@@ -94,7 +100,8 @@ def check_tests(
         LOG.error(err_msg)
         sys.exit(1)
 
-    gh_utils = GitHubAPI(org, repo, token, exclude_contexts=exclude_contexts, include_contexts=include_contexts)
+    gh_utils = GitHubAPI(org, repo, token, exclude_contexts=exclude_contexts,
+                         include_contexts=include_contexts, all_checks=all_checks)
 
     status_success = False
     if input_file:


### PR DESCRIPTION
As in most of the repos, not enough checks are marked under branch protection rules, so we need to flag which, when specified, should go through all the checks of a PR/commit.