### PR TITLE
Use 'npm ci' instead of 'npm install'

### DIFF
--- a/tubular/scripts/frontend_utils.py
+++ b/tubular/scripts/frontend_utils.py
@@ -56,10 +56,10 @@ class FrontendBuilder:
 
     def install_requirements(self):
         """ Install requirements for app to build """
-        proc = subprocess.Popen(['npm install'], cwd=self.app_name, shell=True)
+        proc = subprocess.Popen(['npm ci'], cwd=self.app_name, shell=True)
         return_code = proc.wait()
         if return_code != 0:
-            self.FAIL(1, 'Could not run `npm install` for app {}.'.format(self.app_name))
+            self.FAIL(1, 'Could not run `npm ci` for app {}.'.format(self.app_name))
 
         self.install_requirements_npm_aliases()
 


### PR DESCRIPTION
**Ticket**
[Use 'npm ci' instead of 'npm install' for frontend builds](https://github.com/openedx/frontend-wg/issues/48)

**Description:**
Used 'npm ci' instead of 'npm install' to install dependencies