### PR TITLE
fix: remove future package usages and dependency

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -8,7 +8,6 @@ cloudflare
 edx-opaque-keys==0.4.0
 edx-rest-api-client==5.5.0
 freezegun==0.3.8
-future==0.16.0
 GitPython==3.1.18
 google-api-python-client==1.7.3
 jenkinsapi==0.3.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,9 +42,9 @@ click==8.1.7
     #   edx-django-utils
 click-log==0.4.0
     # via -r requirements/base.in
-cloudflare==2.11.7
+cloudflare==2.12.4
     # via -r requirements/base.in
-cryptography==41.0.3
+cryptography==41.0.4
     # via
     #   pyjwt
     #   simple-salesforce
@@ -64,13 +64,11 @@ easydict==1.10
     # via yagocd
 edx-django-utils==5.7.0
     # via edx-rest-api-client
-edx-opaque-keys==0.4.0
+edx-opaque-keys==0.4
     # via -r requirements/base.in
 edx-rest-api-client==5.5.0
     # via -r requirements/base.in
 freezegun==0.3.8
-    # via -r requirements/base.in
-future==0.16.0
     # via -r requirements/base.in
 gitdb==4.0.10
     # via gitpython
@@ -219,7 +217,7 @@ stevedore==1.32.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via asgiref
 unicodecsv==0.14.1
     # via -r requirements/base.in

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -23,7 +23,7 @@ tomli==2.0.1
     #   pyproject-hooks
 wheel==0.41.2
     # via pip-tools
-zipp==3.16.2
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -36,7 +36,7 @@ code-annotations==1.5.0
     # via edx-lint
 coverage[toml]==7.3.1
     # via pytest-cov
-cryptography==41.0.3
+cryptography==41.0.4
     # via moto
 ddt==1.6.0
     # via -r requirements/testing.in
@@ -163,7 +163,7 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.12.1
     # via pylint
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   astroid
     #   pylint


### PR DESCRIPTION
## Description
- As uncovered in https://pyup.io/vulnerabilities/CVE-2022-40899/52510/, the `future` package is not secure to be used.
- `arbi-bom` is removing `future` package from all repos so this PR is being created under this effort.