### PR TITLE
chore: Allow retirement redrive

### DIFF
--- a/tubular/scripts/retirement_bulk_status_update.py
+++ b/tubular/scripts/retirement_bulk_status_update.py
@@ -81,7 +81,7 @@ def _update_learners_or_exit(config, learners, new_state=None, rewind_state=Fals
     will be reset to their previous state.
     """
     if (not new_state and not rewind_state) or (rewind_state and new_state):
-        raise ValueError("You must specify either the boolean rewind_state or a new state to set learners to.")
+        FAIL(ERR_BAD_CONFIG, "You must specify either the boolean rewind_state or a new state to set learners to.")
     LOG('Updating {} learners to {}'.format(len(learners), new_state))
     try:
         for learner in learners:

--- a/tubular/scripts/retirement_bulk_status_update.py
+++ b/tubular/scripts/retirement_bulk_status_update.py
@@ -74,14 +74,19 @@ def _fetch_learners_to_update_or_exit(config, start_date, end_date, initial_stat
         FAIL_EXCEPTION(ERR_FETCHING, 'Unexpected error occurred fetching users to update!', exc)
 
 
-def _update_learners_or_exit(config, learners, new_state):
+def _update_learners_or_exit(config, learners, new_state=None, rewind_state=False):
     """
     Iterates the list of learners, setting each to the new state. On any error
-    it will exit the script.
+    it will exit the script. If rewind_state is set to True then the learner
+    will be reset to their previous state.
     """
+    if (not new_state and not rewind_state) or (rewind_state and new_state):
+        raise ValueError("You must specify either the boolean rewind_state or a new state to set learners to.")
     LOG('Updating {} learners to {}'.format(len(learners), new_state))
     try:
         for learner in learners:
+            if rewind_state:
+                new_state = learner['last_state']['state_name']
             config['LMS'].update_learner_retirement_state(
                 learner['original_username'],
                 new_state,
@@ -103,7 +108,8 @@ def _update_learners_or_exit(config, learners, new_state):
 )
 @click.option(
     '--new_state',
-    help='Set any found learners to this new state. Use the state name ex: PENDING, COMPLETE'
+    help='Set any found learners to this new state. Use the state name ex: PENDING, COMPLETE',
+    default=None
 )
 @click.option(
     '--start_date',
@@ -115,7 +121,13 @@ def _update_learners_or_exit(config, learners, new_state):
     callback=validate_dates,
     help='(YYYY-MM-DD) Latest creation date for retirements to act on.'
 )
-def update_statuses(config_file, initial_state, new_state, start_date, end_date):
+@click.option(
+    '--rewind-state',
+    help='Rewinds to the last_state for learners. Useful for resetting ERRORED users',
+    default=False,
+    is_flag=True
+)
+def update_statuses(config_file, initial_state, new_state, start_date, end_date, rewind_state):
     """
     Bulk-updates user retirement statuses which are in the specified state -and- retirement was
     requested between a start date and end date.
@@ -130,7 +142,7 @@ def update_statuses(config_file, initial_state, new_state, start_date, end_date)
         SETUP_LMS_OR_EXIT(config)
 
         learners = _fetch_learners_to_update_or_exit(config, start_date, end_date, initial_state)
-        _update_learners_or_exit(config, learners, new_state)
+        _update_learners_or_exit(config, learners, new_state, rewind_state)
 
         LOG('Bulk update complete')
     except Exception as exc:

--- a/tubular/tests/test_retirement_bulk_status_update.py
+++ b/tubular/tests/test_retirement_bulk_status_update.py
@@ -18,7 +18,7 @@ from tubular.scripts.retirement_bulk_status_update import (
 from tubular.tests.retirement_helpers import fake_config_file, get_fake_user_retirement
 
 
-def _call_script(initial_state='COMPLETE', new_state='PENDING', start_date='2018-01-01', end_date='2018-01-15'):
+def _call_script(initial_state='COMPLETE', new_state='PENDING', start_date='2018-01-01', end_date='2018-01-15', rewind_state=False):
     """
     Call the bulk update statuses script with the given params and a generic config file.
     Returns the CliRunner.invoke results
@@ -27,31 +27,33 @@ def _call_script(initial_state='COMPLETE', new_state='PENDING', start_date='2018
     with runner.isolated_filesystem():
         with open('test_config.yml', 'w') as f:
             fake_config_file(f)
-        result = runner.invoke(
-            update_statuses,
-            args=[
+        args = [
                 '--config_file', 'test_config.yml',
                 '--initial_state', initial_state,
-                '--new_state', new_state,
                 '--start_date', start_date,
                 '--end_date', end_date
             ]
+        args.extend(['--new_state', new_state]) if new_state else None
+        args.append('--rewind-state') if rewind_state else None
+        result = runner.invoke(
+            update_statuses,
+            args=args
         )
     print(result)
     print(result.output)
     return result
 
 
-def fake_learners_to_retire():
+def fake_learners_to_retire(**overrides):
     """
     A simple hard-coded list of fake learners with the only piece of
     information this script cares about.
     """
 
     return [
-        get_fake_user_retirement(original_username="user1"),
-        get_fake_user_retirement(original_username="user2"),
-        get_fake_user_retirement(original_username="user3"),
+        get_fake_user_retirement(**{"original_username": "user1", **overrides}),
+        get_fake_user_retirement(**{"original_username": "user2", **overrides}),
+        get_fake_user_retirement(**{"original_username": "user3", **overrides}),
     ]
 
 
@@ -108,6 +110,29 @@ def test_bad_config():
     )
     assert result.exit_code == ERR_BAD_CONFIG
     assert 'does_not_exist.yml' in result.output
+
+@patch('tubular.edx_api.BaseApiClient.get_access_token', return_value=('THIS_IS_A_JWT', None))
+@patch.multiple(
+    'tubular.edx_api.LmsApi',
+    get_learners_by_date_and_status=DEFAULT,
+    update_learner_retirement_state=DEFAULT
+)
+def test_successful_rewind(*args, **kwargs):
+    mock_get_access_token = args[0]
+    mock_get_learners = kwargs['get_learners_by_date_and_status']
+    mock_update_learner_state = kwargs['update_learner_retirement_state']
+
+    mock_get_learners.return_value = fake_learners_to_retire(current_state_name='ERRORED')
+
+    result = _call_script(new_state=None, rewind_state=True)
+
+    # Called once to get the LMS token
+    assert mock_get_access_token.call_count == 1
+    mock_get_learners.assert_called_once()
+    assert mock_update_learner_state.call_count == 3
+
+    assert result.exit_code == 0
+    assert 'Bulk update complete' in result.output
 
 
 @patch('tubular.edx_api.BaseApiClient.get_access_token', return_value=('THIS_IS_A_JWT', None))


### PR DESCRIPTION
This allows the bulk update command to rewind the state of everyone in a particular state to their last known state. This is useful for rewinding a large batch of Errored users.