### PR TITLE
fix: Upgrade boto to the latest version

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,7 +1,7 @@
 -c constraints.txt
 
 backoff==1.5.0
-boto==2.43.0
+boto
 boto3
 click-log
 click>=7.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,11 +10,9 @@ attrs==22.2.0
     # via
     #   jsonlines
     #   zeep
-authlib==1.2.0
-    # via simple-salesforce
 backoff==1.5.0
     # via -r requirements/base.in
-boto==2.43.0
+boto==2.49.0
     # via -r requirements/base.in
 boto3==1.20.22
     # via
@@ -25,7 +23,7 @@ botocore==1.23.22
     #   -c requirements/constraints.txt
     #   boto3
     #   s3transfer
-cachetools==5.2.0
+cachetools==5.3.0
     # via google-auth
 certifi==2022.12.7
     # via
@@ -35,7 +33,7 @@ cffi==1.15.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via
@@ -46,13 +44,13 @@ click-log==0.4.0
     # via -r requirements/base.in
 cloudflare==2.1.0
     # via -r requirements/base.in
-cryptography==39.0.0
-    # via authlib
+cryptography==40.0.1
+    # via pyjwt
 decorator==5.1.1
     # via validators
 deprecated==1.2.13
     # via pygithub
-django==3.2.16
+django==3.2.18
     # via
     #   -c requirements/constraints.txt
     #   django-crum
@@ -63,7 +61,7 @@ django-waffle==3.0.0
     # via edx-django-utils
 easydict==1.10
     # via yagocd
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via edx-rest-api-client
 edx-opaque-keys==0.4.0
     # via -r requirements/base.in
@@ -81,14 +79,14 @@ gitpython==3.1.18
     # via -r requirements/base.in
 google-api-python-client==1.7.3
     # via -r requirements/base.in
-google-auth==2.15.0
+google-auth==2.17.1
     # via
     #   google-api-python-client
     #   google-auth-httplib2
     #   kubernetes
 google-auth-httplib2==0.1.0
     # via google-api-python-client
-httplib2==0.21.0
+httplib2==0.22.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
@@ -108,13 +106,13 @@ kubernetes==12.0.1
     # via -r requirements/base.in
 lxml==4.9.2
     # via zeep
-newrelic==8.5.0
+newrelic==8.8.0
     # via edx-django-utils
 oauthlib==3.2.2
     # via requests-oauthlib
-pbr==5.11.0
+pbr==5.11.1
     # via stevedore
-platformdirs==2.6.2
+platformdirs==3.2.0
     # via zeep
 psutil==5.9.4
     # via edx-django-utils
@@ -126,12 +124,13 @@ pyasn1-modules==0.2.8
     # via google-auth
 pycparser==2.21
     # via cffi
-pygithub==1.57
+pygithub==1.58.1
     # via -r requirements/base.in
-pyjwt==2.6.0
+pyjwt[crypto]==2.6.0
     # via
     #   edx-rest-api-client
     #   pygithub
+    #   simple-salesforce
 pymongo==3.5.1
     # via
     #   -r requirements/base.in
@@ -158,7 +157,7 @@ pyyaml==5.4
     #   -r requirements/base.in
     #   cloudflare
     #   kubernetes
-requests==2.28.1
+requests==2.28.2
     # via
     #   -r requirements/base.in
     #   cloudflare
@@ -186,9 +185,9 @@ s3transfer==0.5.2
     # via boto3
 sailthru-client==2.3.5
     # via -r requirements/base.in
-simple-salesforce==1.12.2
+simple-salesforce==1.12.3
     # via -r requirements/base.in
-simplejson==3.18.1
+simplejson==3.18.4
     # via sailthru-client
 six==1.16.0
     # via
@@ -218,14 +217,14 @@ unicodecsv==0.14.1
     # via -r requirements/base.in
 uritemplate==3.0.1
     # via google-api-python-client
-urllib3==1.26.13
+urllib3==1.26.15
     # via
     #   botocore
     #   kubernetes
     #   requests
 validators==0.20.0
     # via -r requirements/base.in
-websocket-client==1.4.2
+websocket-client==1.5.1
     # via kubernetes
 wrapt==1.11.2
     # via

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,21 +4,19 @@
 #
 #    make upgrade
 #
-build==0.9.0
+build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==22.0
+packaging==23.0
     # via build
-pep517==0.13.0
-    # via build
-pip-tools==6.12.1
+pip-tools==6.12.3
     # via -r requirements/pip-tools.in
+pyproject-hooks==1.0.0
+    # via build
 tomli==2.0.1
-    # via
-    #   build
-    #   pep517
-wheel==0.38.4
+    # via build
+wheel==0.40.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-pip==22.3.1
+pip==23.0.1
     # via -r requirements/pip.in
 setuptools==59.8.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/pip.in
-wheel==0.38.4
+wheel==0.40.0
     # via -r requirements/pip.in

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.12.13
+astroid==2.15.1
     # via
     #   -r requirements/testing.in
     #   pylint
@@ -25,7 +25,7 @@ certifi==2022.12.7
     # via requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via
@@ -36,15 +36,15 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-cryptography==39.0.0
+cryptography==40.0.1
     # via moto
 ddt==1.6.0
     # via -r requirements/testing.in
 dill==0.3.6
     # via pylint
-edx-lint==5.3.0
+edx-lint==5.3.4
     # via -r requirements/testing.in
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via pytest
 execnet==1.9.0
     # via pytest-xdist
@@ -52,9 +52,9 @@ httpretty==1.1.4
     # via -r requirements/testing.in
 idna==3.4
     # via requests
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
-isort==5.11.4
+isort==5.12.0
     # via pylint
 jinja2==3.1.2
     # via
@@ -66,24 +66,24 @@ jmespath==0.10.0
     #   botocore
 lazy-object-proxy==1.9.0
     # via astroid
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
     #   jinja2
     #   moto
     #   werkzeug
 mccabe==0.7.0
     # via pylint
-mock==5.0.0
+mock==5.0.1
     # via -r requirements/testing.in
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via moto
 moto==2.2.11
     # via -r requirements/testing.in
-packaging==22.0
+packaging==23.0
     # via pytest
-pbr==5.11.0
+pbr==5.11.1
     # via stevedore
-platformdirs==2.6.2
+platformdirs==3.2.0
     # via pylint
 pluggy==1.0.0
     # via pytest
@@ -95,7 +95,7 @@ pycodestyle==2.10.0
     #   pytest-pycodestyle
 pycparser==2.21
     # via cffi
-pylint==2.15.9
+pylint==2.17.1
     # via
     #   -r requirements/testing.in
     #   edx-lint
@@ -111,7 +111,7 @@ pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
-pytest==7.2.0
+pytest==7.2.2
     # via
     #   -r requirements/testing.in
     #   pytest-pycodestyle
@@ -121,19 +121,19 @@ pytest-pycodestyle==2.3.1
     # via -r requirements/testing.in
 pytest-pylint==0.19.0
     # via -r requirements/testing.in
-pytest-xdist==3.1.0
+pytest-xdist==3.2.1
     # via -r requirements/testing.in
 python-dateutil==2.8.2
     # via
     #   botocore
     #   moto
-python-slugify==7.0.0
+python-slugify==8.0.1
     # via code-annotations
-pytz==2022.7
+pytz==2023.3
     # via moto
 pyyaml==6.0
     # via code-annotations
-requests==2.28.1
+requests==2.28.2
     # via
     #   moto
     #   requests-mock
@@ -152,7 +152,7 @@ six==1.16.0
     #   edx-lint
     #   python-dateutil
     #   requests-mock
-stevedore==4.1.1
+stevedore==5.0.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
@@ -162,18 +162,18 @@ tomli==2.0.1
     # via
     #   pylint
     #   pytest
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   astroid
     #   pylint
-urllib3==1.26.13
+urllib3==1.26.15
     # via
     #   botocore
     #   requests
     #   responses
-werkzeug==2.2.2
+werkzeug==2.2.3
     # via moto
 wrapt==1.11.2
     # via

--- a/tubular/tests/test_retirement_partner_report.py
+++ b/tubular/tests/test_retirement_partner_report.py
@@ -653,7 +653,7 @@ def test_cleanup_error(*args, **kwargs):
 
     result = _call_script(expect_success=False)
 
-    assert mock_retirement_cleanup.called_with(
+    mock_retirement_cleanup.assert_called_with(
         [user[LEARNER_ORIGINAL_USERNAME_KEY] for user in mock_retirement_report.return_value]
     )
 


### PR DESCRIPTION
Current version of boto 2.43.0 is causing a deployment error in all EC2 based code deployments in GoCD.

The error
```
File "/usr/local/lib/python3.8/dist-packages/backoff/_sync.py", line 99, in retry
    ret = target(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/tubular/ec2.py", line 158, in active_ami_for_edp
    asgs = asg_conn.get_all_groups(names=asgs_for_edp(edp))
  File "/usr/local/lib/python3.8/dist-packages/tubular/ec2.py", line 299, in asgs_for_edp
    tags = {tag.key: tag.value for tag in group.tags}
TypeError: 'NoneType' object is not iterable
```

Upgrade boto to latest version 2.49.0 to see if that unblocks the GoCD deployment pipeline