### PR TITLE
docs: Update the contributing guidelines link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,7 @@ Please see ``LICENSE.txt`` for details.
 
 Contributions are very welcome.
 
-Please read [How To Contribute](https://github.com/openedx/edx-platform/blob/master/CONTRIBUTING.rst) for details.
-
-Even though they were written with ```edx-platform``` in mind, the guidelines
-should be followed for Open edX code in general.
+Please read [How To Contribute](https://github.com/openedx/.github/blob/master/CONTRIBUTING.md) for details.
 
 ## Reporting Security Issues
 


### PR DESCRIPTION
We're moving towards a single set of guidelines org-wide.
