### PR TITLE
Add the ability to optionally consume client_id and secret from env variables

### DIFF
--- a/tubular/scripts/get_learners_to_retire.py
+++ b/tubular/scripts/get_learners_to_retire.py
@@ -70,8 +70,8 @@ def get_learners_to_retire(config_file,
     cool_off_days = int(cool_off_days)
 
     # If the user sets the env variables, override the YAML.
-    client_id = environ.get('TUBULAR_OAUTH_CLIENT_ID', config_yaml['client_id'])
-    client_secret = environ.get('TUBULAR_OAUTH_CLIENT_SECRET', config_yaml['client_secret'])
+    client_id = environ.get('TUBULAR_OAUTH_CLIENT_ID', config_yaml.get('client_id'))
+    client_secret = environ.get('TUBULAR_OAUTH_CLIENT_SECRET', config_yaml.get('client_secret'))
 
     lms_base_url = config_yaml['base_urls']['lms']
     retirement_pipeline = config_yaml['retirement_pipeline']

--- a/tubular/scripts/get_learners_to_retire.py
+++ b/tubular/scripts/get_learners_to_retire.py
@@ -73,7 +73,7 @@ def get_learners_to_retire(config_file,
     client_id = environ.get('TUBULAR_OAUTH_CLIENT_ID', config_yaml.get('client_id'))
     client_secret = environ.get('TUBULAR_OAUTH_CLIENT_SECRET', config_yaml.get('client_secret'))
 
-    lms_base_url = config_yaml['base_urls']['lms']
+    lms_base_url = environ.get('TUBULAR_LMS_HOST',config_yaml.get('base_urls').get('lms'))
     retirement_pipeline = config_yaml['retirement_pipeline']
     end_states = [state[1] for state in retirement_pipeline]
     states_to_request = ['PENDING'] + end_states

--- a/tubular/scripts/get_learners_to_retire.py
+++ b/tubular/scripts/get_learners_to_retire.py
@@ -73,7 +73,7 @@ def get_learners_to_retire(config_file,
     client_id = environ.get('TUBULAR_OAUTH_CLIENT_ID', config_yaml.get('client_id'))
     client_secret = environ.get('TUBULAR_OAUTH_CLIENT_SECRET', config_yaml.get('client_secret'))
 
-    lms_base_url = environ.get('TUBULAR_LMS_HOST',config_yaml.get('base_urls').get('lms'))
+    lms_base_url = environ.get('TUBULAR_LMS_HOST',config_yaml.get('base_urls',{}).get('lms'))
     retirement_pipeline = config_yaml['retirement_pipeline']
     end_states = [state[1] for state in retirement_pipeline]
     states_to_request = ['PENDING'] + end_states

--- a/tubular/scripts/get_learners_to_retire.py
+++ b/tubular/scripts/get_learners_to_retire.py
@@ -69,16 +69,9 @@ def get_learners_to_retire(config_file,
     user_count_error_threshold = int(user_count_error_threshold)
     cool_off_days = int(cool_off_days)
 
-    client_id = config_yaml['client_id']
-    client_secret = config_yaml['client_secret']
-
     # If the user sets the env variables, override the YAML.
-    try:
-        client_id = environ['TUBULAR_OAUTH_CLIENT_ID']
-        client_secret = environ['TUBULAR_OAUTH_CLIENT_SECRET']
-        LOG.info("Overriding YAML client values with contents of TUBULAR_OAUTH_CLIENT_ID and TUBULAR_OAUTH_SECRET")
-    except KeyError:
-        pass
+    client_id = environ.get('TUBULAR_OAUTH_CLIENT_ID', config_yaml['client_id'])
+    client_secret = environ.get('TUBULAR_OAUTH_CLIENT_SECRET', config_yaml['client_secret'])
 
     lms_base_url = config_yaml['base_urls']['lms']
     retirement_pipeline = config_yaml['retirement_pipeline']

--- a/tubular/scripts/helpers.py
+++ b/tubular/scripts/helpers.py
@@ -89,14 +89,11 @@ def _config_or_exit(fail_func, fail_code, config_file):
             config = yaml.safe_load(config)
 
         # Allow override of oauth client_id and client_secret from system environment variables
-        try:
-            config['client_id'] = environ['TUBULAR_OAUTH_CLIENT_ID']
-            config['client_secret'] = environ['TUBULAR_OAUTH_CLIENT_SECRET']
-            _log('oauth_credential_override','Overriding YAML client values with contents of TUBULAR_OAUTH_CLIENT_ID and TUBULAR_OAUTH_SECRET')
-        except KeyError:
-            pass
+        config['client_id'] = environ.get('TUBULAR_OAUTH_CLIENT_ID', config.get('client_id'))
+        config['client_secret'] = environ.get('TUBULAR_OAUTH_CLIENT_SECRET', config.get('client_secret'))
 
         return config
+
     except Exception as exc:  # pylint: disable=broad-except
         fail_func(fail_code, 'Failed to read config file {}'.format(config_file), exc)
 

--- a/tubular/scripts/helpers.py
+++ b/tubular/scripts/helpers.py
@@ -88,7 +88,7 @@ def _config_or_exit(fail_func, fail_code, config_file):
         with io.open(config_file, 'r') as config:
             config = yaml.safe_load(config)
 
-        # Allow override of oauth client_id and client_secret from system environment variables
+        # Allow override of oauth client_id / client_secret from system environment variables
         config['client_id'] = environ.get('TUBULAR_OAUTH_CLIENT_ID', config.get('client_id'))
         config['client_secret'] = environ.get('TUBULAR_OAUTH_CLIENT_SECRET', config.get('client_secret'))
 
@@ -136,7 +136,7 @@ def _setup_lms_api_or_exit(fail_func, fail_code, config):
     Performs setup of EdxRestClientApi for LMS and returns the validated, sorted list of users to report on.
     """
     try:
-        lms_base_url = config['base_urls']['lms']
+        lms_base_url = environ.get('TUBULAR_LMS_HOST',config.get('base_urls').get('lms'))
         client_id = config['client_id']
         client_secret = config['client_secret']
 

--- a/tubular/scripts/helpers.py
+++ b/tubular/scripts/helpers.py
@@ -13,7 +13,7 @@ import json
 import sys
 import traceback
 import unicodedata
-from os import path
+from os import path, environ
 
 import yaml
 from six import text_type
@@ -82,11 +82,19 @@ def _get_error_str_from_exception(exc):
 
 def _config_or_exit(fail_func, fail_code, config_file):
     """
-    Returns the config values from the given file, allows overriding of passed in values.
+    Returns the config values from the given file, allows overriding of client id and secret from the system environment.
     """
     try:
         with io.open(config_file, 'r') as config:
             config = yaml.safe_load(config)
+
+        # Allow override of oauth client_id and client_secret from system environment variables
+        try:
+            config['client_id'] = environ['TUBULAR_OAUTH_CLIENT_ID']
+            config['client_secret'] = environ['TUBULAR_OAUTH_CLIENT_SECRET']
+            _log('oauth_credential_override','Overriding YAML client values with contents of TUBULAR_OAUTH_CLIENT_ID and TUBULAR_OAUTH_SECRET')
+        except KeyError:
+            pass
 
         return config
     except Exception as exc:  # pylint: disable=broad-except

--- a/tubular/scripts/helpers.py
+++ b/tubular/scripts/helpers.py
@@ -114,7 +114,7 @@ def _config_with_drive_or_exit(fail_func, config_fail_code, google_fail_code, co
         # Force the partner names into NFKC here and when we get the folders to ensure
         # they are using the same characters. Otherwise accented characters will not match.
         for org in config['org_partner_mapping']:
-            partner = config['org_partner_mapping'][org]
+            config['org_partner_mapping'][org]
             config['org_partner_mapping'][org] = [unicodedata.normalize('NFKC', text_type(partner)) for partner in config['org_partner_mapping'][org]]
     except Exception as exc:  # pylint: disable=broad-except
         fail_func(config_fail_code, 'Failed to read config file {}'.format(config_file), exc)
@@ -136,7 +136,7 @@ def _setup_lms_api_or_exit(fail_func, fail_code, config):
     Performs setup of EdxRestClientApi for LMS and returns the validated, sorted list of users to report on.
     """
     try:
-        lms_base_url = environ.get('TUBULAR_LMS_HOST',config.get('base_urls').get('lms'))
+        lms_base_url = environ.get('TUBULAR_LMS_HOST',config.get('base_urls',{}).get('lms'))
         client_id = config['client_id']
         client_secret = config['client_secret']
 


### PR DESCRIPTION
Optionally add the capability to consume client_id and client_secret from TUBULAR_CLIENT_ID and TUBULAR_CLIENT_SECRET environment variables rather than in the YAML configuration file.