### PR TITLE
chore: upgrading boto3 and botocore versions.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.7.0
+asgiref==3.7.1
     # via django
 attrs==23.1.0
     # via
@@ -14,11 +14,11 @@ backoff==1.5.0
     # via -r requirements/base.in
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.20.22
+boto3==1.20.54
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-botocore==1.23.22
+botocore==1.23.54
     # via
     #   -c requirements/constraints.txt
     #   boto3
@@ -215,7 +215,7 @@ stevedore==1.32.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==4.6.0
+typing-extensions==4.6.1
     # via asgiref
 unicodecsv==0.14.1
     # via -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,8 +10,8 @@
 
 # TODO: Many pinned dependencies should be unpinned and/or moved to this constraints file.
 
-boto3==1.20.22
-botocore==1.23.22
+boto3==1.20.54
+botocore>=1.23.54,<1.24.0   #https://github.com/boto/boto3/commit/d226d9db05b4fb9d24b4e090efcc752ace5d4985#diff-67fbd34f176dc812829309d74467869a35bf5af2764b626fc1cfb4656c94c633R21
 responses<0.21.0
 django<4.0
 setuptools<60

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -9,11 +9,11 @@ astroid==2.15.5
     #   -r requirements/testing.in
     #   pylint
     #   pylint-celery
-boto3==1.20.22
+boto3==1.20.54
     # via
     #   -c requirements/constraints.txt
     #   moto
-botocore==1.23.22
+botocore==1.23.54
     # via
     #   -c requirements/constraints.txt
     #   boto3
@@ -34,7 +34,7 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-coverage[toml]==7.2.5
+coverage[toml]==7.2.6
     # via pytest-cov
 cryptography==40.0.2
     # via moto
@@ -163,7 +163,7 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.11.8
     # via pylint
-typing-extensions==4.6.0
+typing-extensions==4.6.1
     # via
     #   astroid
     #   pylint


### PR DESCRIPTION
boto3 latest version is `1.26.139`. So instead of directly going there do this in small upgrades to avoid any major failure.

`1.20.54`
https://github.com/boto/boto3/blob/develop/CHANGELOG.rst#L3178