### PR TITLE
Revert "Use 'npm ci' instead of 'npm install'"

### DIFF
--- a/tubular/scripts/frontend_utils.py
+++ b/tubular/scripts/frontend_utils.py
@@ -56,10 +56,10 @@ class FrontendBuilder:
 
     def install_requirements(self):
         """ Install requirements for app to build """
-        proc = subprocess.Popen(['npm ci'], cwd=self.app_name, shell=True)
+        proc = subprocess.Popen(['npm install'], cwd=self.app_name, shell=True)
         return_code = proc.wait()
         if return_code != 0:
-            self.FAIL(1, 'Could not run `npm ci` for app {}.'.format(self.app_name))
+            self.FAIL(1, 'Could not run `npm install` for app {}.'.format(self.app_name))
 
         self.install_requirements_npm_aliases()
 


### PR DESCRIPTION
Reverts openedx/tubular#608

@BilalQamar95 @arbrandes Hey guys, this is causing one of our pipelines to fail. I am going to revert this PR to unblock our current work. 

Failure: https://gocd.tools.edx.org/go/pipelines/stage-frontend-app-admin-portal/580/stage_frontend-app-admin-portal_build_frontend/1

```
[go] Task: /bin/bash -c "frontend_build.py --common-config-file edx-internal/frontends/common/stage_config.yml --env-config-file edx-internal/frontends/frontend-app-admin-portal/stage_config.yml --app-name frontend-app-admin-portal --version-file frontend-app-admin-portal/dist/version.json"took: 2.717sexited: 1
    npm WARN ERESOLVE overriding peer dependency
    npm WARN While resolving: check-prop-types@1.1.2
    npm WARN Found: prop-types@15.7.2
    npm WARN node_modules/prop-types
    npm WARN   prop-types@"15.7.2" from the root project
    npm WARN   27 more (@edx/frontend-enterprise-catalog-search, ...)
    npm WARN 
    npm WARN Could not resolve dependency:
    npm WARN peer prop-types@"<=15.6.0" from check-prop-types@1.1.2
    npm WARN node_modules/dash-embedded-component/node_modules/check-prop-types
    npm WARN   check-prop-types@"^1.1.2" from dash-embedded-component@2.0.2
    npm WARN   node_modules/dash-embedded-component
    npm WARN 
    npm WARN Conflicting peer dependency: prop-types@15.6.0
    npm WARN node_modules/prop-types
    npm WARN   peer prop-types@"<=15.6.0" from check-prop-types@1.1.2
    npm WARN   node_modules/dash-embedded-component/node_modules/check-prop-types
    npm WARN     check-prop-types@"^1.1.2" from dash-embedded-component@2.0.2
    npm WARN     node_modules/dash-embedded-component
    npm ERR! code EUSAGE
    npm ERR! 
    npm ERR! `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
    npm ERR! 
    npm ERR! Missing: mimic-response@1.0.1 from lock file
    npm ERR! Missing: schema-utils@4.0.1 from lock file
    npm ERR! Invalid: lock file's bl@1.2.3 does not satisfy bl@4.1.0
    npm ERR! Missing: buffer@5.7.1 from lock file
    npm ERR! Missing: readable-stream@3.6.2 from lock file
    npm ERR! Missing: base64-js@1.5.1 from lock file
    npm ERR! Missing: ieee754@1.2.1 from lock file
    npm ERR! Missing: ajv@8.12.0 from lock file
    npm ERR! Missing: ajv-keywords@5.1.0 from lock file
    npm ERR! Missing: json-schema-traverse@1.0.0 from lock file
    npm ERR! 
    npm ERR! Clean install a project
    npm ERR! 
    npm ERR! Usage:
    npm ERR! npm ci
    npm ERR! 
    npm ERR! Options:
    npm ERR! [-S|--save|--no-save|--save-prod|--save-dev|--save-optional|--save-peer|--save-bundle]
    npm ERR! [-E|--save-exact] [-g|--global] [--global-style] [--legacy-bundling]
    npm ERR! [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
    npm ERR! [--strict-peer-deps] [--no-package-lock] [--foreground-scripts]
    npm ERR! [--ignore-scripts] [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
    npm ERR! [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
    npm ERR! [-ws|--workspaces] [--include-workspace-root] [--install-links]
    npm ERR! 
    npm ERR! aliases: clean-install, ic, install-clean, isntall-clean
    npm ERR! 
    npm ERR! Run "npm help ci" for more info

    npm ERR! A complete log of this run can be found in:
    npm ERR!     /home/go/.npm/_logs/2023-05-31T20_03_57_016Z-debug-0.log
```

Seems there may be some dependency resolution changes that we need to account for in the `npm ci` command. We could use some lead time before trying this again. Could you please ping me on slack. 