### PR TITLE
fix: Correct filter inputs

### DIFF
--- a/tubular/scripts/cleanup_instances.py
+++ b/tubular/scripts/cleanup_instances.py
@@ -56,7 +56,8 @@ def terminate_instances(region,
     """
     try:
         terminated_instances = ec2.terminate_instances(region,
-                                                       {'key-name': key_name_filter}, max_run_hours, skip_if_tag)
+                                                       {'Name': 'tag:Name', 'Values': [key_name_filter]}, max_run_hours,
+                                                       skip_if_tag)
         logging.info("terminated instances: {}".format(terminated_instances))
     except Exception as err:  # pylint: disable=broad-except
         traceback.print_exc()


### PR DESCRIPTION
After the upgrade form boto to boto3 this code was causing a stack trace like the following.

botocore.exceptions.ParamValidationError: Parameter validation failed:
Unknown parameter in Filters[0]: "key-name", must be one of: Name, Values