### PR TITLE
feat: close alerts via OpsGenie API

### DIFF
--- a/scripts/close_opsgenie_alert.py
+++ b/scripts/close_opsgenie_alert.py
@@ -1,0 +1,1 @@
+../tubular/scripts/alert_opsgenie.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ packages =
 
 [entry_points]
 console_scripts =
+    alert_opsgenie.py = tubular.scripts.alert_opsgenie:alert_opsgenie
     approve_stage.py = tubular.scripts.approve_stage:approve_stage
     asgard-deploy.py = tubular.scripts.asgard_deploy:deploy
     check_migrate_duration.py = tubular.scripts.check_migrate_duration:check_migrate_duration
@@ -24,6 +25,7 @@ console_scripts =
     check_pr_tests_status.py = tubular.scripts.check_pr_tests_status:check_tests
     cleanup-asgs.py = tubular.scripts.cleanup_asgs:delete_asg
     cleanup_instances.py = tubular.scripts.cleanup_instances:terminate_instances
+    close_opsgenie_alert.py = tubular.scripts.close_opsgenie_alert:close_opsgenie_alert
     create_private_to_public_pr.py = tubular.scripts.create_private_to_public_pr:create_private_to_public_pr
     create_tag.py = tubular.scripts.create_tag:create_tag
     delete-asg.py = tubular.scripts.delete_asg:delete_asg
@@ -56,7 +58,6 @@ console_scripts =
     rollback_asg.py = tubular.scripts.rollback_asg:rollback
     structures.py = tubular.scripts.structures:cli
     submit_slack_msg.py = tubular.scripts.submit_slack_msg:submit_slack_msg
-    alert_opsgenie.py = tubular.scripts.alert_opsgenie:alert_opsgenie
 
 [extras]
 dev =

--- a/tubular/opsgenie_api.py
+++ b/tubular/opsgenie_api.py
@@ -3,6 +3,7 @@ A module to provide functionality for reading and manipulating OpsGenie.
 """
 
 import json
+
 from requests import Session
 
 
@@ -21,21 +22,25 @@ class OpsGenieAPI:
         self.session.headers['Authorization'] = "GenieKey {}".format(auth_token)
         self.session.headers['Content-Type'] = 'application/json'
 
-    def alert_opsgenie(self, message, description, responders=None):
+    def alert_opsgenie(self, message, description, responders=None, alias=None,):
         """
         Alert team of an issue - such as GoCD pipeline failure
 
         Arguments:
             message: a summary of the issue
             description: a more detailed description
+            responders: (optional) OpsGenie team name
+            alias: (optional) desired alias for the alert in Opsgenie
         """
         post_url = 'https://api.opsgenie.com/v2/alerts'
         if responders is not None:
             responders = [{"name": responders, "type":"team"}]
+
         alert_data = {
             'message': message,
             'description': description,
             'responders': responders,
+            'alias': alias,
         }
 
         response = self.session.post(
@@ -46,4 +51,29 @@ class OpsGenieAPI:
         if response.status_code not in (200, 201, 202, 204):
             raise OpsgenieMessageSendFailure(
                 "Message {} failed: {}".format(message, response.text)
+            )
+
+    def close_opsgenie_alert_by_alias(self, identifier, source=None):
+        """
+        Close the specified OpsGenie alert
+
+        Arguments:
+            identifier: Alias of the alert to close
+            source: (optional) Source of the request to close to note on the alert
+        """
+
+        post_url = f"https://api.opsgenie.com/v2/alerts/{identifier}/close" \
+                   f"?identifierType=alias"
+
+        response = self.session.post(
+            url=post_url,
+            data=json.dumps({
+                'source': source,
+                'note': f"Closed by {source if source else 'OpsGenieAPI'}"
+            })
+        )
+
+        if response.status_code not in (200, 201, 202, 204):
+            raise OpsgenieMessageSendFailure(
+                f"Request to close {identifier} failed: {response.text}"
             )

--- a/tubular/scripts/alert_opsgenie.py
+++ b/tubular/scripts/alert_opsgenie.py
@@ -2,12 +2,13 @@
 Command-line script to submit an alert to Opsgenie Api.
 """
 
-import sys
 import logging
+import sys
 import traceback
+
 import click
 
-from tubular.opsgenie_api import OpsGenieAPI
+import tubular.opsgenie_api as opsgenie_api
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 LOG = logging.getLogger(__name__)
@@ -33,18 +34,31 @@ LOG = logging.getLogger(__name__)
     default=None,
     help="Who will be paged for this alert",
 )
-def alert_opsgenie(auth_token, message, description, responders):
+@click.option(
+    '--alias',
+    default=None,
+    help="Alias of the OpsGenie alert"
+)
+def alert_opsgenie(auth_token, message, description, responders, alias):
     """
-    Sends an alert to an opsgenie team
+    Create an OpsGenie alert
+
+    Arguments:
+        auth_token: API token
+        message: The alert message
+        description: The alert description
+        responders: The team responsible for the alert
+        alias: The alert alias
     """
     try:
         logging.info("Creating alert on Opsgenie")
-        opsgenie = OpsGenieAPI(auth_token)
-        opsgenie.alert_opsgenie(message, description, responders)
+        opsgenie = opsgenie_api.OpsGenieAPI(auth_token)
+        opsgenie.alert_opsgenie(message, description, responders, alias=alias)
     except Exception as err:  # pylint: disable=broad-except
         traceback.print_exc()
         click.secho('{}'.format(err), fg='red')
         sys.exit(1)
+
 
 if __name__ == "__main__":
     alert_opsgenie()

--- a/tubular/scripts/close_opsgenie_alert.py
+++ b/tubular/scripts/close_opsgenie_alert.py
@@ -1,0 +1,51 @@
+"""
+Command-line script to submit an alert to Opsgenie Api.
+"""
+
+import logging
+import sys
+import traceback
+
+import click
+
+import tubular.opsgenie_api as opsgenie_api
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+@click.command("close_opsgenie_alert")
+@click.option(
+    '--auth_token',
+    required=True,
+    help="Authentication token to use for Opsgenie Alerts API.",
+)
+@click.option(
+    '--alias',
+    required=True,
+    help="Alias of the OpsGenie alert"
+)
+@click.option(
+    '--source',
+    default=None,
+    help="Source of the request"
+)
+def close_opsgenie_alert(auth_token, alias, source):
+    """
+    Close an OpsGenie alert
+
+    Arguments:
+        auth_token: API token
+        alias: The alert alias
+        source: The source of the request
+    """
+    try:
+        logging.info(f"Closing alert {alias} on Opsgenie")
+        opsgenie = opsgenie_api.OpsGenieAPI(auth_token)
+        opsgenie.close_opsgenie_alert_by_alias(alias, source=source)
+    except Exception as err:  # pylint: disable=broad-except
+        traceback.print_exc()
+        click.secho('{}'.format(err), fg='red')
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    close_opsgenie_alert()

--- a/tubular/tests/test_alert_opsgenie.py
+++ b/tubular/tests/test_alert_opsgenie.py
@@ -1,0 +1,46 @@
+import json
+from unittest import TestCase
+from unittest.mock import patch
+
+from click.testing import CliRunner
+from ddt import data, ddt, unpack
+
+import tubular.scripts.alert_opsgenie as ops
+
+
+@ddt
+class TestAlertOpsGenie(TestCase):
+    @unpack
+    @data(  # message, auth-token, description, responders, alias, should_fail
+        ('Message', 'Auth', 'Description', None, None, False),
+        ('Message', 'Auth', 'Description', 'Arch', 'Alias',  False),
+        (None, 'Auth', 'Description', 'Arch', 'Alias', True),
+        ('Message', None, 'Description', 'Arch', 'Alias', True),
+        ('Message', 'Auth', None, 'Arch', 'Alias', True),
+    )
+    def test_create_alert(self, message, auth, description, responders, alias, should_fail):
+        with patch.object(ops.opsgenie_api.Session, 'post') as mock_post:
+            runner = CliRunner()
+            args = ['--message', message, '--auth_token', auth, '--description', description]
+            if responders:
+                args.extend(['--responders', responders])
+            if alias:
+                args.extend(['--alias', alias])
+            invoke_response = runner.invoke(
+                ops.alert_opsgenie,
+                catch_exceptions=False,
+                args=args,
+            )
+            if should_fail:
+                assert invoke_response.exit_code == 2
+        if should_fail:
+            mock_post.assert_not_called()
+        if not should_fail:
+            expected_params = {
+                'message': message,
+                'description': description,
+                'responders': [{"name": responders, "type": "team"}] if responders else None,
+                'alias': alias,
+            }
+            mock_post.assert_called_once_with(url="https://api.opsgenie.com/v2/alerts",
+                                              data=json.dumps(expected_params))

--- a/tubular/tests/test_close_opsgenie_alert.py
+++ b/tubular/tests/test_close_opsgenie_alert.py
@@ -1,0 +1,41 @@
+from unittest import TestCase
+from unittest.mock import patch
+from click.testing import CliRunner
+from ddt import data, ddt, unpack
+import json
+
+import tubular.scripts.close_opsgenie_alert as ops
+
+@ddt
+class TestCloseOpsgenieAlert(TestCase):
+    @unpack
+    @data(  # auth-token, alias, source, should_fail
+        ('Auth', 'Alias', None, False),
+        ('Auth', 'Alias', 'Source', False),
+        (None, 'Alias', None, True),
+        ('Auth', None, None, True)
+    )
+    def test_close_alert(self, auth, alias, source, should_fail):
+        with patch.object(ops.opsgenie_api.Session, 'post') as mock_post:
+            runner = CliRunner()
+            args = ['--auth_token', auth, '--alias', alias]
+            if source:
+                args.extend(['--source', source])
+            invoke_response = runner.invoke(
+                ops.close_opsgenie_alert,
+                catch_exceptions=False,
+                args=args,
+            )
+            if should_fail:
+                assert invoke_response.exit_code == 2
+        if should_fail:
+            mock_post.assert_not_called()
+        if not should_fail:
+            expected_params = {
+                'source': source,
+                'note': f"Closed by {source if source else 'OpsGenieAPI'}",
+            }
+            mock_post.assert_called_once_with(
+                url=f"https://api.opsgenie.com/v2/alerts/{alias}/close?identifierType=alias",
+                data=json.dumps(expected_params)
+            )


### PR DESCRIPTION
Update alert_opsgenie to allow us to add aliases to alerts. This will make them easier to find and close later.
Add close_opsgenie_alert command to allow us to close alerts by alias.
Also adds some tests.
