### PR TITLE
fix: Retry deleting a branch if GitHub says it's unknown

### DIFF
--- a/tubular/scripts/create_private_to_public_pr.py
+++ b/tubular/scripts/create_private_to_public_pr.py
@@ -95,7 +95,7 @@ def create_private_to_public_pr(private_org,
         # Add the public repo as a remote for the private git working tree.
         local_repo.add_remote('public', public_github_url)
         # Create a new public branch with unique name.
-        new_branch_name = 'private_to_public_{}'.format(local_repo.get_head_sha()[:7])
+        new_branch_name = 'private_to_public_{}'.format(local_repo.get_head_sha()[:12])
         # Push the private branch into the public repo.
         LOG.info(
             'Pushing private branch %s to public repo %s as branch %s.',


### PR DESCRIPTION
Try to fix https://github.com/openedx/tubular/issues/687 by allowing retries on `delete_branch`. This may prevent the issue we've seen in `create_private_to_public_pr.py` where the deletion of a newly created branch occasionally fails with a 404.

Also, avoid collisions in SHA prefixes by increasing from 7 to 12 chars. (See commit message for details.)