### PR TITLE
docs: Update the security e-mail address.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Please read [How To Contribute](https://github.com/openedx/.github/blob/master/C
 
 ## Reporting Security Issues
 
-Please do not report security issues in public. Please email security@edx.org.
+Please do not report security issues in public. Please email security@openedx.org.
 
 ## Environment variables
 


### PR DESCRIPTION
This repository is now managed by the Axim Collaborative and security issues
with it should be reported to security@openedx.org instead of security@edx.org

This work is being done as a part of https://github.com/openedx/wg-security/issues/16
