### PR TITLE
chore: update Django to 3.2.23 for Quince - Security Patch

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -47,7 +47,7 @@ cryptography==41.0.4
     #   simple-salesforce
 deprecated==1.2.14
     # via pygithub
-django==3.2.21
+django==3.2.23
     # via
     #   -c requirements/constraints.txt
     #   django-crum


### PR DESCRIPTION
### Description
This PR updates Django to version 3.2.23 in the Quince release branch. The update includes the latest security patch, as part of the BTR working group's ongoing efforts to ensure the security of Open edX's supported named releases.

For more information, see: [https://github.com/openedx/wg-build-test-release/issues/324](https://github.com/openedx/wg-build-test-release/issues/324)